### PR TITLE
flake: refer to Cargo.lock as path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
 
               src = self;
 
-              cargoLock.lockFile = src + "/Cargo.lock";
+              cargoLock.lockFile = ./Cargo.lock;
 
               postPatch = ''
                 substituteInPlace installer/build.rs \


### PR DESCRIPTION
For some reason, using `src + "/Cargo.lock"` makes the builder think it
doesn't exist. I've also experienced this in another, unrelated project.
I don't know what to make of that... Maybe a regression in Nixpkgs?

##### Description

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Built with `cargo build`
- [x] Formatted with `cargo fmt`
- [x] Linted with `cargo clippy`
- [x] Ran tests with `cargo test`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
