### PR TITLE
nixos-module: use the configured systemd version

### DIFF
--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -24,7 +24,7 @@ in
           let
             generatorArgs = lib.escapeShellArgs ([
               "--systemd-machine-id-setup"
-              "${pkgs.systemd}/bin/systemd-machine-id-setup"
+              "${config.systemd.package}/bin/systemd-machine-id-setup"
             ]
             ++ (lib.optionals config.boot.loader.secureboot.enable [
               "--unified-efi"
@@ -33,7 +33,7 @@ in
               "${pkgs.binutils-unwrapped}/bin/objcopy"
 
               "--systemd-efi-stub"
-              "${pkgs.systemd}/lib/systemd/boot/efi/linuxx64.efi.stub"
+              "${config.systemd.package}/lib/systemd/boot/efi/linuxx64.efi.stub"
             ]));
 
             installerArgs = lib.escapeShellArgs
@@ -48,7 +48,7 @@ in
                 (toString config.boot.loader.timeout)
 
                 "--bootctl"
-                "${pkgs.systemd}/bin/bootctl"
+                "${config.systemd.package}/bin/bootctl"
 
                 "--generated-entries"
                 "./systemd-boot-entries"


### PR DESCRIPTION
This ensures that the version is actually the one the user has selected.
This version might contain patches or features that the default systemd
in nixpkgs doesn't provide.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Built with `cargo build`
- [x] Formatted with `cargo fmt`
- [x] Linted with `cargo clippy`
- [x] Ran tests with `cargo test`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
