### PR TITLE
fix: pass --can-touch-efi-vars as per installer

### DIFF
--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -53,7 +53,7 @@ in
                 "--generated-entries"
                 "./systemd-boot-entries"
               ]
-              ++ (lib.optional config.boot.loader.efi.canTouchEfiVariables "--touch-efi-vars")
+              ++ (lib.optional config.boot.loader.efi.canTouchEfiVariables "--can-touch-efi-vars")
               ++ (lib.optionals (config.boot.loader.systemd-boot.configurationLimit != null) [
                 "--configuration-limit"
                 "${toString config.boot.loader.systemd-boot.configurationLimit}"


### PR DESCRIPTION
##### Description

As per https://github.com/DeterminateSystems/bootspec/blob/main/installer/src/main.rs#L53 ; `--can-touch-efi-vars` is the correct argument to pass in the NixOS module.

##### Checklist

Inline change through GitHub UI.

- [ ] Built with `cargo build`
- [ ] Formatted with `cargo fmt`
- [ ] Linted with `cargo clippy`
- [ ] Ran tests with `cargo test`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
