### PR TITLE
Secureboot: pass --unified-efi to the installer too

### DIFF
--- a/installer/src/systemd_boot/mod.rs
+++ b/installer/src/systemd_boot/mod.rs
@@ -142,7 +142,7 @@ fn remove_old_files(generations: &[Generation], path: &Path) -> Result<()> {
     debug!("calculating required filenames");
     let required_filenames = self::get_required_filenames(generations.to_vec());
 
-    trace!("Required files calculated: {:#?}", required_filenames);
+    trace!("required files calculated: {:#?}", required_filenames);
 
     debug!("removing old entries");
     for entry in fs::read_dir(loader_entries)? {
@@ -155,7 +155,7 @@ fn remove_old_files(generations: &[Generation], path: &Path) -> Result<()> {
         }
 
         if !required_filenames.iter().any(|e| e == name) {
-            trace!("Removing entry file {:?}", f);
+            trace!("removing entry file {:?}", f);
             fs::remove_file(f)?;
         }
     }
@@ -166,7 +166,7 @@ fn remove_old_files(generations: &[Generation], path: &Path) -> Result<()> {
         let name = f.file_name().ok_or("filename terminated in ..")?;
 
         if !required_filenames.iter().any(|e| e == name) {
-            trace!("Removing kernel/initrd file {:?}", f);
+            trace!("removing kernel/initrd file {:?}", f);
             fs::remove_file(f)?;
         }
     }

--- a/installer/src/systemd_boot/mod.rs
+++ b/installer/src/systemd_boot/mod.rs
@@ -142,6 +142,8 @@ fn remove_old_files(generations: &[Generation], path: &Path) -> Result<()> {
     debug!("calculating required filenames");
     let required_filenames = self::get_required_filenames(generations.to_vec());
 
+    trace!("Required files calculated: {:#?}", required_filenames);
+
     debug!("removing old entries");
     for entry in fs::read_dir(loader_entries)? {
         let f = entry?.path();
@@ -153,6 +155,7 @@ fn remove_old_files(generations: &[Generation], path: &Path) -> Result<()> {
         }
 
         if !required_filenames.iter().any(|e| e == name) {
+            trace!("Removing entry file {:?}", f);
             fs::remove_file(f)?;
         }
     }
@@ -163,6 +166,7 @@ fn remove_old_files(generations: &[Generation], path: &Path) -> Result<()> {
         let name = f.file_name().ok_or("filename terminated in ..")?;
 
         if !required_filenames.iter().any(|e| e == name) {
+            trace!("Removing kernel/initrd file {:?}", f);
             fs::remove_file(f)?;
         }
     }

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -67,6 +67,8 @@ in
                 config.boot.loader.secureboot.signingCertPath
               ])
               ++ (lib.optionals config.boot.loader.secureboot.enable [
+                "--unified-efi"
+
                 "--sbsign"
                 "${pkgs.sbsigntool}/bin/sbsign"
 


### PR DESCRIPTION
##### Description

IF we're not using unified EFI, the unified EFIs get deleted. Oops! Not sure how this worked before :).

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [ ] Built with `cargo build`
- [ ] Formatted with `cargo fmt`
- [ ] Linted with `cargo clippy`
- [ ] Ran tests with `cargo test`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
