### PR TITLE
validate: init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
+name = "validate"
+version = "0.1.0"
+dependencies = [
+ "bootspec",
+ "serde_json",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
   "bootspec",
   "synthesize",
+  "validate",
 ]

--- a/bootspec/src/generation.rs
+++ b/bootspec/src/generation.rs
@@ -18,11 +18,24 @@ pub enum Generation {
     V1(v1::GenerationV1),
 }
 
+impl Generation {
+    /// The version of the bootspec document.
+    pub fn version(&self) -> u64 {
+        use Generation::*;
+
+        match self {
+            V1(_) => v1::SCHEMA_VERSION,
+        }
+    }
+}
+
 impl Serialize for Generation {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
+        use Generation::*;
+
         #[derive(Serialize)]
         struct TypedGeneration {
             #[serde(rename = "schemaVersion")]
@@ -32,7 +45,7 @@ impl Serialize for Generation {
         }
 
         let msg = match self {
-            Generation::V1(gen) => TypedGeneration {
+            V1(gen) => TypedGeneration {
                 v: v1::SCHEMA_VERSION,
                 msg: serde_json::to_value(gen).map_err(S::Error::custom)?,
             },

--- a/validate/Cargo.toml
+++ b/validate/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "validate"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bootspec = { version = "0.1.0", path = "../bootspec" }
+serde_json = "1.0.81"

--- a/validate/README.md
+++ b/validate/README.md
@@ -1,0 +1,12 @@
+# validate
+
+The `validate` tool is used to validate a [bootspec] document produced
+by any tool against the specification.
+
+[bootspec]: https://github.com/NixOS/rfcs/pull/125
+
+## Usage
+
+```terminal
+$ validate /path/to/bootspec/json/document
+```

--- a/validate/src/main.rs
+++ b/validate/src/main.rs
@@ -16,17 +16,7 @@ fn main() -> Result<()> {
 }
 
 fn cli() -> Result<()> {
-    let mut args = std::env::args().skip(1);
-
-    if args.len() != 1 {
-        writeln!(io::stderr(), "Usage: validate <bootspec_path>")?;
-        std::process::exit(1);
-    }
-
-    let bootspec_path = args
-        .next()
-        .ok_or("Expected path to bootspec document, got none.")?
-        .parse::<PathBuf>()?;
+    let Args { bootspec_path } = parse_args()?;
 
     let contents = fs::read_to_string(&bootspec_path)?;
 
@@ -48,4 +38,24 @@ fn cli() -> Result<()> {
     }
 
     Ok(())
+}
+
+pub struct Args {
+    pub bootspec_path: PathBuf,
+}
+
+fn parse_args() -> Result<Args> {
+    let mut args = std::env::args().skip(1);
+
+    if args.len() != 1 {
+        writeln!(io::stderr(), "Usage: validate <bootspec_path>")?;
+        std::process::exit(1);
+    }
+
+    let bootspec_path = args
+        .next()
+        .ok_or("Expected path to bootspec document, got none.")?
+        .parse::<PathBuf>()?;
+
+    Ok(Args { bootspec_path })
 }

--- a/validate/src/main.rs
+++ b/validate/src/main.rs
@@ -1,0 +1,51 @@
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use bootspec::generation::Generation;
+use bootspec::Result;
+
+fn main() -> Result<()> {
+    if let Err(e) = self::cli() {
+        writeln!(io::stderr(), "{}", e)?;
+
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+fn cli() -> Result<()> {
+    let mut args = std::env::args().skip(1);
+
+    if args.len() != 1 {
+        writeln!(io::stderr(), "Usage: validate <bootspec_path>")?;
+        std::process::exit(1);
+    }
+
+    let bootspec_path = args
+        .next()
+        .ok_or("Expected path to bootspec document, got none.")?
+        .parse::<PathBuf>()?;
+
+    let contents = fs::read_to_string(&bootspec_path)?;
+
+    match serde_json::from_str::<Generation>(&contents) {
+        Ok(generation) => writeln!(
+            io::stdout(),
+            "Bootspec document at '{}' IS a valid v{} document.",
+            bootspec_path.display(),
+            generation.version()
+        )?,
+        Err(err) => {
+            return Err(format!(
+                "Bootspec document at '{}' IS NOT a valid document:\n{}",
+                bootspec_path.display(),
+                err
+            )
+            .into())
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Also add a way to get the version from the Generation enum variant, for
a more specific "success" message.

##### Description

Depends on https://github.com/DeterminateSystems/bootspec/pull/4. (based on it for minimal diff)

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Built with `cargo build`
- [x] Formatted with `cargo fmt`
- [x] Linted with `cargo clippy`
- [x] Ran tests with `cargo test`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)

---

Drafted until https://github.com/DeterminateSystems/bootspec/pull/4 is merged.

TODO:
~~- [ ] also validate specialisation `schemaVersion`s (must match top-level `schemaVersion`)?~~