### PR TITLE
bootspec/generation: version key in document

### DIFF
--- a/synthesize/integration-test-cases/expected-synthesis/15.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/15.09-plain.json
@@ -1,13 +1,14 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 15.09pre-git (Linux 3.18.21)",
-  "kernel": "/nix/store/vvabsbnxmh8nx6pq0bkk6vpsy5cqf9i5-linux-3.18.21/bzImage",
-  "kernelParams": [
-    "loglevel=4"
-  ],
-  "init": "/nix/store/fl1c8cclzzri16zimdfz8wp31w5yc7dp-nixos-15.09pre-git/init",
-  "initrd": "/nix/store/gqdm8dk6my53kvn23r81win9vadjqv80-initrd/initrd",
-  "initrdSecrets": null,
-  "specialisation": {},
-  "toplevel": "/nix/store/fl1c8cclzzri16zimdfz8wp31w5yc7dp-nixos-15.09pre-git"
+  "v1": {
+    "label": "NixOS 15.09pre-git (Linux 3.18.21)",
+    "kernel": "/nix/store/vvabsbnxmh8nx6pq0bkk6vpsy5cqf9i5-linux-3.18.21/bzImage",
+    "kernelParams": [
+      "loglevel=4"
+    ],
+    "init": "/nix/store/fl1c8cclzzri16zimdfz8wp31w5yc7dp-nixos-15.09pre-git/init",
+    "initrd": "/nix/store/gqdm8dk6my53kvn23r81win9vadjqv80-initrd/initrd",
+    "initrdSecrets": null,
+    "specialisation": {},
+    "toplevel": "/nix/store/fl1c8cclzzri16zimdfz8wp31w5yc7dp-nixos-15.09pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/16.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/16.03-plain.json
@@ -1,13 +1,14 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 16.03pre-git (Linux 4.4.6)",
-  "kernel": "/nix/store/vmsl93kyx72kh03m0h6r2w5ivywbjxm6-linux-4.4.6/bzImage",
-  "kernelParams": [
-    "loglevel=4"
-  ],
-  "init": "/nix/store/k0lfhjxd5znyrqkgrdi3hh7wxr885fcj-nixos-system-nixos-16.03pre-git/init",
-  "initrd": "/nix/store/q1hg158mvnc9bscc22cv45ys484c4g9x-initrd/initrd",
-  "initrdSecrets": null,
-  "specialisation": {},
-  "toplevel": "/nix/store/k0lfhjxd5znyrqkgrdi3hh7wxr885fcj-nixos-system-nixos-16.03pre-git"
+  "v1": {
+    "label": "NixOS 16.03pre-git (Linux 4.4.6)",
+    "kernel": "/nix/store/vmsl93kyx72kh03m0h6r2w5ivywbjxm6-linux-4.4.6/bzImage",
+    "kernelParams": [
+      "loglevel=4"
+    ],
+    "init": "/nix/store/k0lfhjxd5znyrqkgrdi3hh7wxr885fcj-nixos-system-nixos-16.03pre-git/init",
+    "initrd": "/nix/store/q1hg158mvnc9bscc22cv45ys484c4g9x-initrd/initrd",
+    "initrdSecrets": null,
+    "specialisation": {},
+    "toplevel": "/nix/store/k0lfhjxd5znyrqkgrdi3hh7wxr885fcj-nixos-system-nixos-16.03pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/16.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/16.09-plain.json
@@ -1,13 +1,14 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 16.09pre-git (Linux 4.4.23)",
-  "kernel": "/nix/store/x58d7k8lczvh4qsqaj4jky1hzpc788b4-linux-4.4.23/bzImage",
-  "kernelParams": [
-    "loglevel=4"
-  ],
-  "init": "/nix/store/jfwlp9s434kijn4i53fr5pvrryzspwc4-nixos-system-nixos-16.09pre-git/init",
-  "initrd": "/nix/store/rv6i771w5z01z1xvylxhymp5pw44wc6j-initrd/initrd",
-  "initrdSecrets": null,
-  "specialisation": {},
-  "toplevel": "/nix/store/jfwlp9s434kijn4i53fr5pvrryzspwc4-nixos-system-nixos-16.09pre-git"
+  "v1": {
+    "label": "NixOS 16.09pre-git (Linux 4.4.23)",
+    "kernel": "/nix/store/x58d7k8lczvh4qsqaj4jky1hzpc788b4-linux-4.4.23/bzImage",
+    "kernelParams": [
+      "loglevel=4"
+    ],
+    "init": "/nix/store/jfwlp9s434kijn4i53fr5pvrryzspwc4-nixos-system-nixos-16.09pre-git/init",
+    "initrd": "/nix/store/rv6i771w5z01z1xvylxhymp5pw44wc6j-initrd/initrd",
+    "initrdSecrets": null,
+    "specialisation": {},
+    "toplevel": "/nix/store/jfwlp9s434kijn4i53fr5pvrryzspwc4-nixos-system-nixos-16.09pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/17.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/17.03-plain.json
@@ -1,13 +1,14 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 17.03pre-git (Linux 4.9.18)",
-  "kernel": "/nix/store/syp5ycwxv6yvfv2c9aq3wwqilxpnjvry-linux-4.9.18/bzImage",
-  "kernelParams": [
-    "loglevel=4"
-  ],
-  "init": "/nix/store/51yf3by1xpzawi30a1rny34gm1047vg8-nixos-system-nixos-17.03pre-git/init",
-  "initrd": "/nix/store/spbi6va9dmd41rg15nd9wxjj94097q49-initrd/initrd",
-  "initrdSecrets": null,
-  "specialisation": {},
-  "toplevel": "/nix/store/51yf3by1xpzawi30a1rny34gm1047vg8-nixos-system-nixos-17.03pre-git"
+  "v1": {
+    "label": "NixOS 17.03pre-git (Linux 4.9.18)",
+    "kernel": "/nix/store/syp5ycwxv6yvfv2c9aq3wwqilxpnjvry-linux-4.9.18/bzImage",
+    "kernelParams": [
+      "loglevel=4"
+    ],
+    "init": "/nix/store/51yf3by1xpzawi30a1rny34gm1047vg8-nixos-system-nixos-17.03pre-git/init",
+    "initrd": "/nix/store/spbi6va9dmd41rg15nd9wxjj94097q49-initrd/initrd",
+    "initrdSecrets": null,
+    "specialisation": {},
+    "toplevel": "/nix/store/51yf3by1xpzawi30a1rny34gm1047vg8-nixos-system-nixos-17.03pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/17.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/17.09-plain.json
@@ -1,13 +1,14 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 17.09pre-git (Linux 4.9.52)",
-  "kernel": "/nix/store/8i1sk0wbwliz0rrpmcq19nm1xlyjn6zg-linux-4.9.52/bzImage",
-  "kernelParams": [
-    "loglevel=4"
-  ],
-  "init": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git/init",
-  "initrd": "/nix/store/nnyp0dqb62dicr9wyw2ykcrc0vk7f5mf-initrd/initrd",
-  "initrdSecrets": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git/append-initrd-secrets",
-  "specialisation": {},
-  "toplevel": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git"
+  "v1": {
+    "label": "NixOS 17.09pre-git (Linux 4.9.52)",
+    "kernel": "/nix/store/8i1sk0wbwliz0rrpmcq19nm1xlyjn6zg-linux-4.9.52/bzImage",
+    "kernelParams": [
+      "loglevel=4"
+    ],
+    "init": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git/init",
+    "initrd": "/nix/store/nnyp0dqb62dicr9wyw2ykcrc0vk7f5mf-initrd/initrd",
+    "initrdSecrets": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git/append-initrd-secrets",
+    "specialisation": {},
+    "toplevel": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/18.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/18.03-plain.json
@@ -1,13 +1,14 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 18.03pre-git (Linux 4.14.32)",
-  "kernel": "/nix/store/n1fhfw5pyggaybsixvm0haq2h67biah0-linux-4.14.32/bzImage",
-  "kernelParams": [
-    "loglevel=4"
-  ],
-  "init": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git/init",
-  "initrd": "/nix/store/gnjk07h7ynhp3f8x145dv224j0wf0s1h-initrd/initrd",
-  "initrdSecrets": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git/append-initrd-secrets",
-  "specialisation": {},
-  "toplevel": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git"
+  "v1": {
+    "label": "NixOS 18.03pre-git (Linux 4.14.32)",
+    "kernel": "/nix/store/n1fhfw5pyggaybsixvm0haq2h67biah0-linux-4.14.32/bzImage",
+    "kernelParams": [
+      "loglevel=4"
+    ],
+    "init": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git/init",
+    "initrd": "/nix/store/gnjk07h7ynhp3f8x145dv224j0wf0s1h-initrd/initrd",
+    "initrdSecrets": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git/append-initrd-secrets",
+    "specialisation": {},
+    "toplevel": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/18.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/18.09-plain.json
@@ -1,13 +1,14 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 18.09pre-git (Linux 4.14.74)",
-  "kernel": "/nix/store/s1kjv7xs8gaqw2mfhga0yppyl7k78jnf-linux-4.14.74/bzImage",
-  "kernelParams": [
-    "loglevel=4"
-  ],
-  "init": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git/init",
-  "initrd": "/nix/store/2ib32agl00qy7sf7ka5sdbrl6kg4b9gi-initrd/initrd",
-  "initrdSecrets": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git/append-initrd-secrets",
-  "specialisation": {},
-  "toplevel": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git"
+  "v1": {
+    "label": "NixOS 18.09pre-git (Linux 4.14.74)",
+    "kernel": "/nix/store/s1kjv7xs8gaqw2mfhga0yppyl7k78jnf-linux-4.14.74/bzImage",
+    "kernelParams": [
+      "loglevel=4"
+    ],
+    "init": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git/init",
+    "initrd": "/nix/store/2ib32agl00qy7sf7ka5sdbrl6kg4b9gi-initrd/initrd",
+    "initrdSecrets": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git/append-initrd-secrets",
+    "specialisation": {},
+    "toplevel": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/19.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/19.03-plain.json
@@ -1,13 +1,14 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 19.03pre-git (Linux 4.19.34)",
-  "kernel": "/nix/store/3wbab1zxpil3ia7flkmzl8j3qds09dbw-linux-4.19.34/bzImage",
-  "kernelParams": [
-    "loglevel=4"
-  ],
-  "init": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git/init",
-  "initrd": "/nix/store/fv9ag95k2ww4w87grwj6hg0b25is5giy-initrd/initrd",
-  "initrdSecrets": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git/append-initrd-secrets",
-  "specialisation": {},
-  "toplevel": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git"
+  "v1": {
+    "label": "NixOS 19.03pre-git (Linux 4.19.34)",
+    "kernel": "/nix/store/3wbab1zxpil3ia7flkmzl8j3qds09dbw-linux-4.19.34/bzImage",
+    "kernelParams": [
+      "loglevel=4"
+    ],
+    "init": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git/init",
+    "initrd": "/nix/store/fv9ag95k2ww4w87grwj6hg0b25is5giy-initrd/initrd",
+    "initrdSecrets": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git/append-initrd-secrets",
+    "specialisation": {},
+    "toplevel": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/19.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/19.09-plain.json
@@ -1,14 +1,15 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 19.09pre-git (Linux 4.19.78)",
-  "kernel": "/nix/store/s7zp6i6r73a0sri2fihmpnwbqrpsk8fs-linux-4.19.78/bzImage",
-  "kernelParams": [
-    "loglevel=4",
-    "net.ifnames=0"
-  ],
-  "init": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git/init",
-  "initrd": "/nix/store/d6xpsfsby2y1d2hvfhdgss45swrazipf-initrd-linux-4.19.78/initrd",
-  "initrdSecrets": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git/append-initrd-secrets",
-  "specialisation": {},
-  "toplevel": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git"
+  "v1": {
+    "label": "NixOS 19.09pre-git (Linux 4.19.78)",
+    "kernel": "/nix/store/s7zp6i6r73a0sri2fihmpnwbqrpsk8fs-linux-4.19.78/bzImage",
+    "kernelParams": [
+      "loglevel=4",
+      "net.ifnames=0"
+    ],
+    "init": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git/init",
+    "initrd": "/nix/store/d6xpsfsby2y1d2hvfhdgss45swrazipf-initrd-linux-4.19.78/initrd",
+    "initrdSecrets": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git/append-initrd-secrets",
+    "specialisation": {},
+    "toplevel": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/20.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/20.03-plain.json
@@ -1,14 +1,15 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 20.03pre-git (Linux 5.4.33)",
-  "kernel": "/nix/store/li3v6p9mqsspm0zgglzba2szab2zdmiv-linux-5.4.33/bzImage",
-  "kernelParams": [
-    "loglevel=4",
-    "net.ifnames=0"
-  ],
-  "init": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git/init",
-  "initrd": "/nix/store/1j7s94v0axvgwcv4s0ka56xmgvffdlc0-initrd-linux-5.4.33/initrd",
-  "initrdSecrets": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git/append-initrd-secrets",
-  "specialisation": {},
-  "toplevel": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git"
+  "v1": {
+    "label": "NixOS 20.03pre-git (Linux 5.4.33)",
+    "kernel": "/nix/store/li3v6p9mqsspm0zgglzba2szab2zdmiv-linux-5.4.33/bzImage",
+    "kernelParams": [
+      "loglevel=4",
+      "net.ifnames=0"
+    ],
+    "init": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git/init",
+    "initrd": "/nix/store/1j7s94v0axvgwcv4s0ka56xmgvffdlc0-initrd-linux-5.4.33/initrd",
+    "initrdSecrets": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git/append-initrd-secrets",
+    "specialisation": {},
+    "toplevel": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/20.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/20.09-plain.json
@@ -1,14 +1,15 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 20.09pre-git (Linux 5.4.72)",
-  "kernel": "/nix/store/ysrwgw1wp9ha0484dh8q1awysn9vfxdy-linux-5.4.72/bzImage",
-  "kernelParams": [
-    "loglevel=4",
-    "net.ifnames=0"
-  ],
-  "init": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git/init",
-  "initrd": "/nix/store/r7ifs7qvxb5fdz7hhjh5m8a65k34ik25-initrd-linux-5.4.72/initrd",
-  "initrdSecrets": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git/append-initrd-secrets",
-  "specialisation": {},
-  "toplevel": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git"
+  "v1": {
+    "label": "NixOS 20.09pre-git (Linux 5.4.72)",
+    "kernel": "/nix/store/ysrwgw1wp9ha0484dh8q1awysn9vfxdy-linux-5.4.72/bzImage",
+    "kernelParams": [
+      "loglevel=4",
+      "net.ifnames=0"
+    ],
+    "init": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git/init",
+    "initrd": "/nix/store/r7ifs7qvxb5fdz7hhjh5m8a65k34ik25-initrd-linux-5.4.72/initrd",
+    "initrdSecrets": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git/append-initrd-secrets",
+    "specialisation": {},
+    "toplevel": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/21.05-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/21.05-plain.json
@@ -1,14 +1,15 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 21.05pre-git (Linux 5.10.37)",
-  "kernel": "/nix/store/rrmsyrg9ksd9x2cqb01pmbw0yd0anf7v-linux-5.10.37/bzImage",
-  "kernelParams": [
-    "loglevel=4",
-    "net.ifnames=0"
-  ],
-  "init": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git/init",
-  "initrd": "/nix/store/5ci6pag0hclx1642nm5rs6zjl60drns4-initrd-linux-5.10.37/initrd",
-  "initrdSecrets": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git/append-initrd-secrets",
-  "specialisation": {},
-  "toplevel": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git"
+  "v1": {
+    "label": "NixOS 21.05pre-git (Linux 5.10.37)",
+    "kernel": "/nix/store/rrmsyrg9ksd9x2cqb01pmbw0yd0anf7v-linux-5.10.37/bzImage",
+    "kernelParams": [
+      "loglevel=4",
+      "net.ifnames=0"
+    ],
+    "init": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git/init",
+    "initrd": "/nix/store/5ci6pag0hclx1642nm5rs6zjl60drns4-initrd-linux-5.10.37/initrd",
+    "initrdSecrets": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git/append-initrd-secrets",
+    "specialisation": {},
+    "toplevel": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/21.11-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/21.11-plain.json
@@ -1,14 +1,15 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 21.11pre-git (Linux 5.10.81)",
-  "kernel": "/nix/store/hprwry55jwyd71ng7v7c2rhk3a3z1im8-linux-5.10.81/bzImage",
-  "kernelParams": [
-    "loglevel=4",
-    "net.ifnames=0"
-  ],
-  "init": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git/init",
-  "initrd": "/nix/store/69bhfdfv77y0vclnlxqrd8pxjzbkz47w-initrd-linux-5.10.81/initrd",
-  "initrdSecrets": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
-  "specialisation": {},
-  "toplevel": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git"
+  "v1": {
+    "label": "NixOS 21.11pre-git (Linux 5.10.81)",
+    "kernel": "/nix/store/hprwry55jwyd71ng7v7c2rhk3a3z1im8-linux-5.10.81/bzImage",
+    "kernelParams": [
+      "loglevel=4",
+      "net.ifnames=0"
+    ],
+    "init": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git/init",
+    "initrd": "/nix/store/69bhfdfv77y0vclnlxqrd8pxjzbkz47w-initrd-linux-5.10.81/initrd",
+    "initrdSecrets": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
+    "specialisation": {},
+    "toplevel": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/21.11-specialisations.json
+++ b/synthesize/integration-test-cases/expected-synthesis/21.11-specialisations.json
@@ -1,29 +1,29 @@
 {
-  "schemaVersion": 1,
-  "label": "NixOS 21.11pre-git (Linux 5.10.81)",
-  "kernel": "/nix/store/hprwry55jwyd71ng7v7c2rhk3a3z1im8-linux-5.10.81/bzImage",
-  "kernelParams": [
-    "loglevel=4",
-    "net.ifnames=0"
-  ],
-  "init": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git/init",
-  "initrd": "/nix/store/69bhfdfv77y0vclnlxqrd8pxjzbkz47w-initrd-linux-5.10.81/initrd",
-  "initrdSecrets": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
-  "specialisation": {
-    "example": {
-      "schemaVersion": 1,
-      "label": "NixOS 21.11pre-git (Linux 5.10.81)",
-      "kernel": "/nix/store/hprwry55jwyd71ng7v7c2rhk3a3z1im8-linux-5.10.81/bzImage",
-      "kernelParams": [
-        "loglevel=4",
-        "net.ifnames=0"
-      ],
-      "init": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git/init",
-      "initrd": "/nix/store/69bhfdfv77y0vclnlxqrd8pxjzbkz47w-initrd-linux-5.10.81/initrd",
-      "initrdSecrets": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
-      "specialisation": {},
-      "toplevel": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git"
-    }
-  },
-  "toplevel": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git"
+  "v1": {
+    "label": "NixOS 21.11pre-git (Linux 5.10.81)",
+    "kernel": "/nix/store/hprwry55jwyd71ng7v7c2rhk3a3z1im8-linux-5.10.81/bzImage",
+    "kernelParams": [
+      "loglevel=4",
+      "net.ifnames=0"
+    ],
+    "init": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git/init",
+    "initrd": "/nix/store/69bhfdfv77y0vclnlxqrd8pxjzbkz47w-initrd-linux-5.10.81/initrd",
+    "initrdSecrets": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
+    "specialisation": {
+      "example": {
+        "label": "NixOS 21.11pre-git (Linux 5.10.81)",
+        "kernel": "/nix/store/hprwry55jwyd71ng7v7c2rhk3a3z1im8-linux-5.10.81/bzImage",
+        "kernelParams": [
+          "loglevel=4",
+          "net.ifnames=0"
+        ],
+        "init": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git/init",
+        "initrd": "/nix/store/69bhfdfv77y0vclnlxqrd8pxjzbkz47w-initrd-linux-5.10.81/initrd",
+        "initrdSecrets": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
+        "specialisation": {},
+        "toplevel": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git"
+      }
+    },
+    "toplevel": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git"
+  }
 }

--- a/synthesize/integration-test-cases/verify.sh
+++ b/synthesize/integration-test-cases/verify.sh
@@ -12,7 +12,7 @@ done) | xargs --max-procs=$(nproc) --max-lines=1 nix-build
 rm -rf generated-synthesis
 mkdir generated-synthesis
 for out in ./builds/*; do
-    cargo run --bin synthesize -- "$out" "./generated-synthesis/$(basename "$out").json"
+    cargo run --bin synthesize -- --version=1 "$out" "./generated-synthesis/$(basename "$out").json"
 done
 
 diff -r ./expected-synthesis ./generated-synthesis


### PR DESCRIPTION
Documents will now have a toplevel `vX` key in order to version the
document, instead of a specific `schemaVersion` field.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Built with `cargo build`
- [x] Formatted with `cargo fmt`
- [x] Linted with `cargo clippy`
- [x] Ran tests with `cargo test`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
