### PR TITLE
Implement Lanzaboote needs wrt to Bootspec library

### DIFF
--- a/bootspec/src/generation.rs
+++ b/bootspec/src/generation.rs
@@ -173,9 +173,10 @@ mod tests {
     }
 
     #[test]
-    fn valid_v1_json_with_typed_optional_extension_fields() {
+    fn valid_v1_json_with_typed_optional_extension_fields_and_empty_object() {
         let json = r#"{
     "v1": {
+        "system": "x86_64-linux",
         "init": "/nix/store/xxx-nixos-system-xxx/init",
         "initrd": "/nix/store/xxx-initrd-linux/initrd",
         "initrdSecrets": "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
@@ -201,6 +202,7 @@ mod tests {
         let Generation::V1(from_json) = from_json;
 
         let expected = crate::v1::GenerationV1 {
+            system: String::from("x86_64-linux"),
             label: String::from("NixOS 21.11.20210810.dirty (Linux 5.15.30)"),
             kernel: PathBuf::from("/nix/store/xxx-linux/bzImage"),
             kernel_params: vec![
@@ -217,7 +219,7 @@ mod tests {
             .map(ToString::to_string)
             .collect(),
             init: PathBuf::from("/nix/store/xxx-nixos-system-xxx/init"),
-            initrd: PathBuf::from("/nix/store/xxx-initrd-linux/initrd"),
+            initrd: Some(PathBuf::from("/nix/store/xxx-initrd-linux/initrd")),
             initrd_secrets: Some(PathBuf::from(
                 "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
             )),
@@ -228,6 +230,35 @@ mod tests {
 
         assert_eq!(from_json, expected);
     }
+
+    #[test]
+    fn invalid_v1_json_with_typed_optional_extension_fields_and_null() {
+        let json = r#"{
+    "v1": {
+        "init": "/nix/store/xxx-nixos-system-xxx/init",
+        "initrd": "/nix/store/xxx-initrd-linux/initrd",
+        "initrdSecrets": "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
+        "kernel": "/nix/store/xxx-linux/bzImage",
+        "kernelParams": [
+            "amd_iommu=on",
+            "amd_iommu=pt",
+            "iommu=pt",
+            "kvm.ignore_msrs=1",
+            "kvm.report_ignored_msrs=0",
+            "udev.log_priority=3",
+            "systemd.unified_cgroup_hierarchy=1",
+            "loglevel=4"
+        ],
+        "label": "NixOS 21.11.20210810.dirty (Linux 5.15.30)",
+        "toplevel": "/nix/store/xxx-nixos-system-xxx",
+        "specialisation": {},
+        "extensions": null
+    }
+}"#;
+        let json_err = serde_json::from_str::<Generation>(&json).unwrap_err();
+        assert!(json_err.to_string().contains("expected missing field"));
+    }
+
     #[test]
     fn valid_v1_json_without_extension() {
         let json = r#"{
@@ -287,7 +318,7 @@ mod tests {
     }
 
     #[test]
-    fn valid_v1_json_with_null_extension() {
+    fn invalid_v1_json_with_null_extension() {
         let json = r#"{
     "v1": {
         "system": "x86_64-linux",
@@ -312,37 +343,8 @@ mod tests {
     }
 }"#;
 
-        let from_json: Generation = serde_json::from_str(&json).unwrap();
-        let Generation::V1(from_json) = from_json;
-
-        let expected = crate::v1::GenerationV1 {
-            system: String::from("x86_64-linux"),
-            label: String::from("NixOS 21.11.20210810.dirty (Linux 5.15.30)"),
-            kernel: PathBuf::from("/nix/store/xxx-linux/bzImage"),
-            kernel_params: vec![
-                "amd_iommu=on",
-                "amd_iommu=pt",
-                "iommu=pt",
-                "kvm.ignore_msrs=1",
-                "kvm.report_ignored_msrs=0",
-                "udev.log_priority=3",
-                "systemd.unified_cgroup_hierarchy=1",
-                "loglevel=4",
-            ]
-            .iter()
-            .map(ToString::to_string)
-            .collect(),
-            init: PathBuf::from("/nix/store/xxx-nixos-system-xxx/init"),
-            initrd: Some(PathBuf::from("/nix/store/xxx-initrd-linux/initrd")),
-            initrd_secrets: Some(PathBuf::from(
-                "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
-            )),
-            specialisation: HashMap::new(),
-            extensions: None,
-            toplevel: SystemConfigurationRoot(PathBuf::from("/nix/store/xxx-nixos-system-xxx")),
-        };
-
-        assert_eq!(from_json, expected);
+        let json_err = serde_json::from_str::<Generation>(&json).unwrap_err();
+        assert!(json_err.to_string().contains("expected missing field"));
     }
 
     #[test]
@@ -363,7 +365,8 @@ mod tests {
             "loglevel=4"
         ],
         "label": "NixOS 21.11.20210810.dirty (Linux 5.15.30)",
-        "toplevel": "/nix/store/xxx-nixos-system-xxx"
+        "toplevel": "/nix/store/xxx-nixos-system-xxx",
+        "extensions": {}
     }
 }"#;
 
@@ -391,7 +394,7 @@ mod tests {
             initrd: None,
             initrd_secrets: None,
             specialisation: HashMap::new(),
-            extensions: None,
+            extensions: Some(HashMap::new()),
             toplevel: SystemConfigurationRoot(PathBuf::from("/nix/store/xxx-nixos-system-xxx")),
         };
 

--- a/bootspec/src/generation.rs
+++ b/bootspec/src/generation.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::v1;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 /// An enum of all available bootspec versions.

--- a/bootspec/src/generation.rs
+++ b/bootspec/src/generation.rs
@@ -76,6 +76,7 @@ mod tests {
         let Generation::V1(from_json) = from_json;
 
         let expected = crate::v1::GenerationV1 {
+            system: String::from("x86_64-linux"),
             label: String::from("NixOS 21.11.20210810.dirty (Linux 5.15.30)"),
             kernel: PathBuf::from("/nix/store/xxx-linux/bzImage"),
             kernel_params: vec![
@@ -92,7 +93,7 @@ mod tests {
             .map(ToString::to_string)
             .collect(),
             init: PathBuf::from("/nix/store/xxx-nixos-system-xxx/init"),
-            initrd: PathBuf::from("/nix/store/xxx-initrd-linux/initrd"),
+            initrd: Some(PathBuf::from("/nix/store/xxx-initrd-linux/initrd")),
             initrd_secrets: Some(PathBuf::from(
                 "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
             )),
@@ -133,6 +134,7 @@ mod tests {
         let Generation::V1(from_json) = from_json;
 
         let expected = crate::v1::GenerationV1 {
+            system: String::from("x86_64-linux"),
             label: String::from("NixOS 21.11.20210810.dirty (Linux 5.15.30)"),
             kernel: PathBuf::from("/nix/store/xxx-linux/bzImage"),
             kernel_params: vec![
@@ -149,7 +151,7 @@ mod tests {
             .map(ToString::to_string)
             .collect(),
             init: PathBuf::from("/nix/store/xxx-nixos-system-xxx/init"),
-            initrd: PathBuf::from("/nix/store/xxx-initrd-linux/initrd"),
+            initrd: Some(PathBuf::from("/nix/store/xxx-initrd-linux/initrd")),
             initrd_secrets: Some(PathBuf::from(
                 "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
             )),
@@ -221,7 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn valid_v1_json_without_initrd() {
+    fn valid_v1_json_without_initrd_and_specialisation() {
         let json = r#"{
     "v1": {
         "system": "x86_64-linux",
@@ -239,7 +241,6 @@ mod tests {
         ],
         "label": "NixOS 21.11.20210810.dirty (Linux 5.15.30)",
         "toplevel": "/nix/store/xxx-nixos-system-xxx",
-        "specialisation": {}
     }
 }"#;
 
@@ -267,6 +268,7 @@ mod tests {
             initrd: None,
             initrd_secrets: None,
             specialisation: HashMap::new(),
+            extensions: None,
             toplevel: SystemConfigurationRoot(PathBuf::from("/nix/store/xxx-nixos-system-xxx")),
         };
 

--- a/bootspec/src/generation.rs
+++ b/bootspec/src/generation.rs
@@ -109,6 +109,7 @@ mod tests {
     fn valid_v1_json_with_typed_extension() {
         let json = r#"{
     "v1": {
+        "system": "x86_64-linux",
         "init": "/nix/store/xxx-nixos-system-xxx/init",
         "initrd": "/nix/store/xxx-initrd-linux/initrd",
         "initrdSecrets": "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
@@ -169,6 +170,7 @@ mod tests {
     fn valid_v1_json_without_extension() {
         let json = r#"{
     "v1": {
+        "system": "x86_64-linux",
         "init": "/nix/store/xxx-nixos-system-xxx/init",
         "initrd": "/nix/store/xxx-initrd-linux/initrd",
         "initrdSecrets": "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
@@ -223,6 +225,65 @@ mod tests {
     }
 
     #[test]
+    fn valid_v1_json_with_null_extension() {
+        let json = r#"{
+    "v1": {
+        "system": "x86_64-linux",
+        "init": "/nix/store/xxx-nixos-system-xxx/init",
+        "initrd": "/nix/store/xxx-initrd-linux/initrd",
+        "initrdSecrets": "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
+        "kernel": "/nix/store/xxx-linux/bzImage",
+        "kernelParams": [
+            "amd_iommu=on",
+            "amd_iommu=pt",
+            "iommu=pt",
+            "kvm.ignore_msrs=1",
+            "kvm.report_ignored_msrs=0",
+            "udev.log_priority=3",
+            "systemd.unified_cgroup_hierarchy=1",
+            "loglevel=4"
+        ],
+        "label": "NixOS 21.11.20210810.dirty (Linux 5.15.30)",
+        "toplevel": "/nix/store/xxx-nixos-system-xxx",
+        "specialisation": {},
+        "extensions": null
+    }
+}"#;
+
+        let from_json: Generation = serde_json::from_str(&json).unwrap();
+        let Generation::V1(from_json) = from_json;
+
+        let expected = crate::v1::GenerationV1 {
+            system: String::from("x86_64-linux"),
+            label: String::from("NixOS 21.11.20210810.dirty (Linux 5.15.30)"),
+            kernel: PathBuf::from("/nix/store/xxx-linux/bzImage"),
+            kernel_params: vec![
+                "amd_iommu=on",
+                "amd_iommu=pt",
+                "iommu=pt",
+                "kvm.ignore_msrs=1",
+                "kvm.report_ignored_msrs=0",
+                "udev.log_priority=3",
+                "systemd.unified_cgroup_hierarchy=1",
+                "loglevel=4",
+            ]
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
+            init: PathBuf::from("/nix/store/xxx-nixos-system-xxx/init"),
+            initrd: Some(PathBuf::from("/nix/store/xxx-initrd-linux/initrd")),
+            initrd_secrets: Some(PathBuf::from(
+                "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
+            )),
+            specialisation: HashMap::new(),
+            extensions: None,
+            toplevel: SystemConfigurationRoot(PathBuf::from("/nix/store/xxx-nixos-system-xxx")),
+        };
+
+        assert_eq!(from_json, expected);
+    }
+
+    #[test]
     fn valid_v1_json_without_initrd_and_specialisation() {
         let json = r#"{
     "v1": {
@@ -240,7 +301,7 @@ mod tests {
             "loglevel=4"
         ],
         "label": "NixOS 21.11.20210810.dirty (Linux 5.15.30)",
-        "toplevel": "/nix/store/xxx-nixos-system-xxx",
+        "toplevel": "/nix/store/xxx-nixos-system-xxx"
     }
 }"#;
 
@@ -273,6 +334,34 @@ mod tests {
         };
 
         assert_eq!(from_json, expected);
+    }
+
+    #[test]
+    fn invalid_v1_json_with_null_specialisation() {
+        let json = r#"{
+    "v1": {
+        "init": "/nix/store/xxx-nixos-system-xxx/init",
+        "initrd": "/nix/store/xxx-initrd-linux/initrd",
+        "initrdSecrets": "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
+        "kernel": "/nix/store/xxx-linux/bzImage",
+        "kernelParams": [
+            "amd_iommu=on",
+            "amd_iommu=pt",
+            "iommu=pt",
+            "kvm.ignore_msrs=1",
+            "kvm.report_ignored_msrs=0",
+            "udev.log_priority=3",
+            "systemd.unified_cgroup_hierarchy=1",
+            "loglevel=4"
+        ],
+        "label": "NixOS 21.11.20210810.dirty (Linux 5.15.30)",
+        "toplevel": "/nix/store/xxx-nixos-system-xxx",
+        "specialisation": null
+    }
+}"#;
+
+        let json_err = serde_json::from_str::<Generation>(&json).unwrap_err();
+        assert!(json_err.to_string().contains("expected a map"));
     }
 
     #[test]

--- a/bootspec/src/generation.rs
+++ b/bootspec/src/generation.rs
@@ -14,11 +14,11 @@ use crate::v1;
 ///
 /// This enum is nonexhaustive, because there may be future versions added at any point, and tools
 /// should explicitly handle them (e.g. by noting they're currently unsupported).
-pub enum Generation<Extension: Default = HashMap<String, serde_json::Value>> {
+pub enum Generation<Extension = HashMap<String, serde_json::Value>> {
     V1(v1::GenerationV1<Extension>),
 }
 
-impl<Extension: Default> Generation<Extension> {
+impl<Extension> Generation<Extension> {
     /// The version of the bootspec document.
     pub fn version(&self) -> u64 {
         use Generation::*;
@@ -97,7 +97,7 @@ mod tests {
                 "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
             )),
             specialisation: HashMap::new(),
-            extensions: HashMap::new(),
+            extensions: Some(HashMap::new()),
             toplevel: SystemConfigurationRoot(PathBuf::from("/nix/store/xxx-nixos-system-xxx")),
         };
 
@@ -154,9 +154,9 @@ mod tests {
                 "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
             )),
             specialisation: HashMap::new(),
-            extensions: TestExtension {
+            extensions: Some(TestExtension {
                 test: "hello".to_string(),
-            },
+            }),
             toplevel: SystemConfigurationRoot(PathBuf::from("/nix/store/xxx-nixos-system-xxx")),
         };
 
@@ -213,7 +213,7 @@ mod tests {
                 "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
             )),
             specialisation: HashMap::new(),
-            extensions: HashMap::new(),
+            extensions: None,
             toplevel: SystemConfigurationRoot(PathBuf::from("/nix/store/xxx-nixos-system-xxx")),
         };
 

--- a/bootspec/src/lib.rs
+++ b/bootspec/src/lib.rs
@@ -28,13 +28,13 @@ pub struct SystemConfigurationRoot(pub PathBuf);
 /// The bootspec schema filename.
 pub const JSON_FILENAME: &str = "boot.json";
 
-// !!! IMPORTANT: KEEP `BootJson` and `SCHEMA_VERSION` IN SYNC !!!
+// !!! IMPORTANT: KEEP `BootJson`, `Extension`, and `SCHEMA_VERSION` IN SYNC !!!
 /// The current bootspec schema.
 pub type BootJson = v1::GenerationV1;
-/// The current bootspec schema version.
-pub const SCHEMA_VERSION: u64 = v1::SCHEMA_VERSION;
 /// The current Extension type.
 pub type Extension = v1::Extension;
+/// The current bootspec schema version.
+pub const SCHEMA_VERSION: u64 = v1::SCHEMA_VERSION;
 
 // Enable conversions from Generation into the current Bootspec schema.
 impl TryFrom<generation::Generation> for BootJson {

--- a/bootspec/src/lib.rs
+++ b/bootspec/src/lib.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::fmt;
 
 use std::error::Error;
@@ -33,3 +34,14 @@ pub const JSON_FILENAME: &str = "boot.json";
 pub type BootJson<Extension> = v1::GenerationV1<Extension>;
 /// The current bootspec schema version.
 pub const SCHEMA_VERSION: u64 = v1::SCHEMA_VERSION;
+
+// Enable conversions from Generation into the current Bootspec schema.
+impl<Extension> TryFrom<generation::Generation<Extension>> for BootJson<Extension> {
+    type Error = &'static str;
+
+    fn try_from(value: generation::Generation<Extension>) -> Result<Self, Self::Error> {
+        match value {
+            generation::Generation::V1(boot_json) => Ok(boot_json),
+        }
+    }
+}

--- a/bootspec/src/lib.rs
+++ b/bootspec/src/lib.rs
@@ -1,7 +1,6 @@
 use std::convert::TryFrom;
-use std::fmt;
-
 use std::error::Error;
+use std::fmt;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -31,15 +30,17 @@ pub const JSON_FILENAME: &str = "boot.json";
 
 // !!! IMPORTANT: KEEP `BootJson` and `SCHEMA_VERSION` IN SYNC !!!
 /// The current bootspec schema.
-pub type BootJson<Extension> = v1::GenerationV1<Extension>;
+pub type BootJson = v1::GenerationV1;
 /// The current bootspec schema version.
 pub const SCHEMA_VERSION: u64 = v1::SCHEMA_VERSION;
+/// The current Extension type.
+pub type Extension = v1::Extension;
 
 // Enable conversions from Generation into the current Bootspec schema.
-impl<Extension> TryFrom<generation::Generation<Extension>> for BootJson<Extension> {
+impl TryFrom<generation::Generation> for BootJson {
     type Error = &'static str;
 
-    fn try_from(value: generation::Generation<Extension>) -> Result<Self, Self::Error> {
+    fn try_from(value: generation::Generation) -> Result<Self, Self::Error> {
         match value {
             generation::Generation::V1(boot_json) => Ok(boot_json),
         }

--- a/bootspec/src/lib.rs
+++ b/bootspec/src/lib.rs
@@ -30,6 +30,6 @@ pub const JSON_FILENAME: &str = "boot.json";
 
 // !!! IMPORTANT: KEEP `BootJson` and `SCHEMA_VERSION` IN SYNC !!!
 /// The current bootspec schema.
-pub type BootJson = v1::GenerationV1;
+pub type BootJson<Extension> = v1::GenerationV1<Extension>;
 /// The current bootspec schema version.
 pub const SCHEMA_VERSION: u64 = v1::SCHEMA_VERSION;

--- a/bootspec/src/lib.rs
+++ b/bootspec/src/lib.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use std::error::Error;
 use std::path::PathBuf;
 
@@ -12,6 +14,12 @@ pub type Result<T, E = Box<dyn Error + Send + Sync + 'static>> = core::result::R
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 /// A wrapper type describing the name of a NixOS specialisation.
 pub struct SpecialisationName(pub String);
+
+impl fmt::Display for SpecialisationName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 /// A wrapper type describing the root directory of a NixOS system configuration.

--- a/bootspec/src/v1.rs
+++ b/bootspec/src/v1.rs
@@ -37,6 +37,8 @@ pub struct GenerationV1 {
     pub system: String,
     /// config.system.build.toplevel path
     pub toplevel: SystemConfigurationRoot,
+    /// User extensions for this specification
+    pub extensions: HashMap<String, serde_json::Value>,
 }
 
 impl GenerationV1 {
@@ -126,6 +128,7 @@ impl GenerationV1 {
             system,
             toplevel: SystemConfigurationRoot(generation),
             specialisation: HashMap::new(),
+            extensions: HashMap::new()
         })
     }
 }

--- a/bootspec/src/v1.rs
+++ b/bootspec/src/v1.rs
@@ -9,7 +9,7 @@ use crate::{Result, SpecialisationName, SystemConfigurationRoot};
 /// The V1 bootspec schema version.
 pub const SCHEMA_VERSION: u64 = 1;
 
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 /// V1 of the bootspec schema.
 ///

--- a/bootspec/src/v1.rs
+++ b/bootspec/src/v1.rs
@@ -9,7 +9,7 @@ use crate::{Result, SpecialisationName, SystemConfigurationRoot};
 /// The V1 bootspec schema version.
 pub const SCHEMA_VERSION: u64 = 1;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 /// V1 of the bootspec schema.
 ///
@@ -38,8 +38,8 @@ pub struct GenerationV1<Extension = HashMap<String, serde_json::Value>> {
     /// config.system.build.toplevel path
     pub toplevel: SystemConfigurationRoot,
     /// User extensions for this specification
-    #[serde(default)]
-    pub extensions: Extension,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<Extension>,
 }
 
 impl GenerationV1 {
@@ -129,7 +129,7 @@ impl GenerationV1 {
             system,
             toplevel: SystemConfigurationRoot(generation),
             specialisation: HashMap::new(),
-            extensions: HashMap::new(),
+            extensions: None,
         })
     }
 }
@@ -250,7 +250,7 @@ mod tests {
                 initrd_secrets: Some(generation.join("append-initrd-secrets")),
                 specialisation: HashMap::new(),
                 toplevel: SystemConfigurationRoot(generation),
-                extensions: HashMap::new()
+                extensions: None
             }
         );
     }
@@ -321,7 +321,7 @@ mod tests {
                 initrd_secrets: Some(generation.join("append-initrd-secrets")),
                 specialisation: HashMap::new(),
                 toplevel: SystemConfigurationRoot(generation),
-                extensions: HashMap::new()
+                extensions: None
             }
         );
     }

--- a/bootspec/src/v1.rs
+++ b/bootspec/src/v1.rs
@@ -18,7 +18,7 @@ pub const SCHEMA_VERSION: u64 = 1;
 /// Do not attempt to deserialize this struct from a bootspec document, as it does not enforce
 /// versioning. You want to use the [`crate::generation::Generation`] enum for both
 /// serialization and deserialization.
-pub struct GenerationV1 {
+pub struct GenerationV1<Extension = HashMap<String, serde_json::Value>> {
     /// Label for the system closure
     pub label: String,
     /// Path to kernel (bzImage) -- $toplevel/kernel
@@ -31,14 +31,15 @@ pub struct GenerationV1 {
     pub initrd: Option<PathBuf>,
     /// Path to "append-initrd-secrets" script -- $toplevel/append-initrd-secrets
     pub initrd_secrets: Option<PathBuf>,
-    /// Mapping of specialisation names to their boot.json
-    pub specialisation: HashMap<SpecialisationName, GenerationV1>,
     /// System double, e.g. x86_64-linux, for the system closure
     pub system: String,
+    /// Mapping of specialisation names to their boot.json
+    pub specialisation: HashMap<SpecialisationName, GenerationV1<Extension>>,
     /// config.system.build.toplevel path
     pub toplevel: SystemConfigurationRoot,
     /// User extensions for this specification
-    pub extensions: HashMap<String, serde_json::Value>,
+    #[serde(default)]
+    pub extensions: Extension,
 }
 
 impl GenerationV1 {
@@ -128,7 +129,7 @@ impl GenerationV1 {
             system,
             toplevel: SystemConfigurationRoot(generation),
             specialisation: HashMap::new(),
-            extensions: HashMap::new()
+            extensions: HashMap::new(),
         })
     }
 }
@@ -249,6 +250,7 @@ mod tests {
                 initrd_secrets: Some(generation.join("append-initrd-secrets")),
                 specialisation: HashMap::new(),
                 toplevel: SystemConfigurationRoot(generation),
+                extensions: HashMap::new()
             }
         );
     }
@@ -319,6 +321,7 @@ mod tests {
                 initrd_secrets: Some(generation.join("append-initrd-secrets")),
                 specialisation: HashMap::new(),
                 toplevel: SystemConfigurationRoot(generation),
+                extensions: HashMap::new()
             }
         );
     }

--- a/bootspec/src/v1.rs
+++ b/bootspec/src/v1.rs
@@ -34,6 +34,7 @@ pub struct GenerationV1<Extension = HashMap<String, serde_json::Value>> {
     /// System double, e.g. x86_64-linux, for the system closure
     pub system: String,
     /// Mapping of specialisation names to their boot.json
+    #[serde(default = "HashMap::new")]
     pub specialisation: HashMap<SpecialisationName, GenerationV1<Extension>>,
     /// config.system.build.toplevel path
     pub toplevel: SystemConfigurationRoot,

--- a/bootspec/src/v1.rs
+++ b/bootspec/src/v1.rs
@@ -9,7 +9,7 @@ use crate::{Result, SpecialisationName, SystemConfigurationRoot};
 /// The V1 bootspec schema version.
 pub const SCHEMA_VERSION: u64 = 1;
 
-/// User-specific extension data
+/// User-specified extension data
 pub type Extension = HashMap<String, serde_json::Value>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/synthesize/integration-test-cases/expected-synthesis/15.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/15.09-plain.json
@@ -10,6 +10,7 @@
     "initrdSecrets": null,
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/fl1c8cclzzri16zimdfz8wp31w5yc7dp-nixos-15.09pre-git"
+    "toplevel": "/nix/store/fl1c8cclzzri16zimdfz8wp31w5yc7dp-nixos-15.09pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/15.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/15.09-plain.json
@@ -8,9 +8,8 @@
     "init": "/nix/store/fl1c8cclzzri16zimdfz8wp31w5yc7dp-nixos-15.09pre-git/init",
     "initrd": "/nix/store/gqdm8dk6my53kvn23r81win9vadjqv80-initrd/initrd",
     "initrdSecrets": null,
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/fl1c8cclzzri16zimdfz8wp31w5yc7dp-nixos-15.09pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/fl1c8cclzzri16zimdfz8wp31w5yc7dp-nixos-15.09pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/16.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/16.03-plain.json
@@ -8,9 +8,8 @@
     "init": "/nix/store/k0lfhjxd5znyrqkgrdi3hh7wxr885fcj-nixos-system-nixos-16.03pre-git/init",
     "initrd": "/nix/store/q1hg158mvnc9bscc22cv45ys484c4g9x-initrd/initrd",
     "initrdSecrets": null,
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/k0lfhjxd5znyrqkgrdi3hh7wxr885fcj-nixos-system-nixos-16.03pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/k0lfhjxd5znyrqkgrdi3hh7wxr885fcj-nixos-system-nixos-16.03pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/16.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/16.03-plain.json
@@ -10,6 +10,7 @@
     "initrdSecrets": null,
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/k0lfhjxd5znyrqkgrdi3hh7wxr885fcj-nixos-system-nixos-16.03pre-git"
+    "toplevel": "/nix/store/k0lfhjxd5znyrqkgrdi3hh7wxr885fcj-nixos-system-nixos-16.03pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/16.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/16.09-plain.json
@@ -10,6 +10,7 @@
     "initrdSecrets": null,
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/jfwlp9s434kijn4i53fr5pvrryzspwc4-nixos-system-nixos-16.09pre-git"
+    "toplevel": "/nix/store/jfwlp9s434kijn4i53fr5pvrryzspwc4-nixos-system-nixos-16.09pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/16.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/16.09-plain.json
@@ -8,9 +8,8 @@
     "init": "/nix/store/jfwlp9s434kijn4i53fr5pvrryzspwc4-nixos-system-nixos-16.09pre-git/init",
     "initrd": "/nix/store/rv6i771w5z01z1xvylxhymp5pw44wc6j-initrd/initrd",
     "initrdSecrets": null,
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/jfwlp9s434kijn4i53fr5pvrryzspwc4-nixos-system-nixos-16.09pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/jfwlp9s434kijn4i53fr5pvrryzspwc4-nixos-system-nixos-16.09pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/17.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/17.03-plain.json
@@ -8,9 +8,8 @@
     "init": "/nix/store/51yf3by1xpzawi30a1rny34gm1047vg8-nixos-system-nixos-17.03pre-git/init",
     "initrd": "/nix/store/spbi6va9dmd41rg15nd9wxjj94097q49-initrd/initrd",
     "initrdSecrets": null,
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/51yf3by1xpzawi30a1rny34gm1047vg8-nixos-system-nixos-17.03pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/51yf3by1xpzawi30a1rny34gm1047vg8-nixos-system-nixos-17.03pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/17.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/17.03-plain.json
@@ -10,6 +10,7 @@
     "initrdSecrets": null,
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/51yf3by1xpzawi30a1rny34gm1047vg8-nixos-system-nixos-17.03pre-git"
+    "toplevel": "/nix/store/51yf3by1xpzawi30a1rny34gm1047vg8-nixos-system-nixos-17.03pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/17.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/17.09-plain.json
@@ -8,9 +8,8 @@
     "init": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git/init",
     "initrd": "/nix/store/nnyp0dqb62dicr9wyw2ykcrc0vk7f5mf-initrd/initrd",
     "initrdSecrets": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git/append-initrd-secrets",
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/17.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/17.09-plain.json
@@ -10,6 +10,7 @@
     "initrdSecrets": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git/append-initrd-secrets",
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git"
+    "toplevel": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/18.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/18.03-plain.json
@@ -8,9 +8,8 @@
     "init": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git/init",
     "initrd": "/nix/store/gnjk07h7ynhp3f8x145dv224j0wf0s1h-initrd/initrd",
     "initrdSecrets": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git/append-initrd-secrets",
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/18.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/18.03-plain.json
@@ -10,6 +10,7 @@
     "initrdSecrets": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git/append-initrd-secrets",
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git"
+    "toplevel": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/18.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/18.09-plain.json
@@ -10,6 +10,7 @@
     "initrdSecrets": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git/append-initrd-secrets",
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git"
+    "toplevel": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/18.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/18.09-plain.json
@@ -8,9 +8,8 @@
     "init": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git/init",
     "initrd": "/nix/store/2ib32agl00qy7sf7ka5sdbrl6kg4b9gi-initrd/initrd",
     "initrdSecrets": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git/append-initrd-secrets",
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/19.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/19.03-plain.json
@@ -10,6 +10,7 @@
     "initrdSecrets": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git/append-initrd-secrets",
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git"
+    "toplevel": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/19.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/19.03-plain.json
@@ -8,9 +8,8 @@
     "init": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git/init",
     "initrd": "/nix/store/fv9ag95k2ww4w87grwj6hg0b25is5giy-initrd/initrd",
     "initrdSecrets": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git/append-initrd-secrets",
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/19.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/19.09-plain.json
@@ -11,6 +11,7 @@
     "initrdSecrets": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git/append-initrd-secrets",
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git"
+    "toplevel": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/19.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/19.09-plain.json
@@ -9,9 +9,8 @@
     "init": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git/init",
     "initrd": "/nix/store/d6xpsfsby2y1d2hvfhdgss45swrazipf-initrd-linux-4.19.78/initrd",
     "initrdSecrets": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git/append-initrd-secrets",
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/20.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/20.03-plain.json
@@ -11,6 +11,7 @@
     "initrdSecrets": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git/append-initrd-secrets",
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git"
+    "toplevel": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/20.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/20.03-plain.json
@@ -9,9 +9,8 @@
     "init": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git/init",
     "initrd": "/nix/store/1j7s94v0axvgwcv4s0ka56xmgvffdlc0-initrd-linux-5.4.33/initrd",
     "initrdSecrets": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git/append-initrd-secrets",
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/20.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/20.09-plain.json
@@ -11,6 +11,7 @@
     "initrdSecrets": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git/append-initrd-secrets",
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git"
+    "toplevel": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/20.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/20.09-plain.json
@@ -9,9 +9,8 @@
     "init": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git/init",
     "initrd": "/nix/store/r7ifs7qvxb5fdz7hhjh5m8a65k34ik25-initrd-linux-5.4.72/initrd",
     "initrdSecrets": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git/append-initrd-secrets",
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/21.05-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/21.05-plain.json
@@ -11,6 +11,7 @@
     "initrdSecrets": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git/append-initrd-secrets",
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git"
+    "toplevel": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/21.05-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/21.05-plain.json
@@ -9,9 +9,8 @@
     "init": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git/init",
     "initrd": "/nix/store/5ci6pag0hclx1642nm5rs6zjl60drns4-initrd-linux-5.10.37/initrd",
     "initrdSecrets": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git/append-initrd-secrets",
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/21.11-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/21.11-plain.json
@@ -9,9 +9,8 @@
     "init": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git/init",
     "initrd": "/nix/store/69bhfdfv77y0vclnlxqrd8pxjzbkz47w-initrd-linux-5.10.81/initrd",
     "initrdSecrets": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
-    "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git",
-    "extensions": {}
+    "specialisation": {},
+    "toplevel": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/21.11-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/21.11-plain.json
@@ -11,6 +11,7 @@
     "initrdSecrets": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
     "specialisation": {},
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git"
+    "toplevel": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git",
+    "extensions": {}
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/21.11-specialisations.json
+++ b/synthesize/integration-test-cases/expected-synthesis/21.11-specialisations.json
@@ -9,6 +9,7 @@
     "init": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git/init",
     "initrd": "/nix/store/69bhfdfv77y0vclnlxqrd8pxjzbkz47w-initrd-linux-5.10.81/initrd",
     "initrdSecrets": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
+    "system": "x86_64-linux",
     "specialisation": {
       "example": {
         "label": "NixOS 21.11pre-git (Linux 5.10.81)",
@@ -20,14 +21,11 @@
         "init": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git/init",
         "initrd": "/nix/store/69bhfdfv77y0vclnlxqrd8pxjzbkz47w-initrd-linux-5.10.81/initrd",
         "initrdSecrets": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
-        "specialisation": {},
         "system": "x86_64-linux",
-        "toplevel": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git",
-        "extensions": {}
+        "specialisation": {},
+        "toplevel": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git"
       }
     },
-    "system": "x86_64-linux",
-    "toplevel": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git",
-    "extensions": {}
+    "toplevel": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/21.11-specialisations.json
+++ b/synthesize/integration-test-cases/expected-synthesis/21.11-specialisations.json
@@ -22,10 +22,12 @@
         "initrdSecrets": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
         "specialisation": {},
         "system": "x86_64-linux",
-        "toplevel": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git"
+        "toplevel": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git",
+        "extensions": {}
       }
     },
     "system": "x86_64-linux",
-    "toplevel": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git"
+    "toplevel": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git",
+    "extensions": {}
   }
 }


### PR DESCRIPTION
##### Description

Fixes #67, #66.

##### Checklist

- [x] Built with `cargo build`
- [x] Formatted with `cargo fmt`
- [x] Linted with `cargo clippy`
- [x] Ran tests with `cargo test`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
