### PR TITLE
Optional initrd & system field

### DIFF
--- a/bootspec/src/generation.rs
+++ b/bootspec/src/generation.rs
@@ -40,6 +40,7 @@ mod tests {
     fn valid_v1_json() {
         let json = r#"{
     "v1": {
+        "system": "x86_64-linux",
         "init": "/nix/store/xxx-nixos-system-xxx/init",
         "initrd": "/nix/store/xxx-initrd-linux/initrd",
         "initrdSecrets": "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
@@ -64,6 +65,7 @@ mod tests {
         let Generation::V1(from_json) = from_json;
 
         let expected = crate::v1::GenerationV1 {
+            system: String::from("x86_64-linux"),
             label: String::from("NixOS 21.11.20210810.dirty (Linux 5.15.30)"),
             kernel: PathBuf::from("/nix/store/xxx-linux/bzImage"),
             kernel_params: vec![

--- a/bootspec/src/generation.rs
+++ b/bootspec/src/generation.rs
@@ -82,10 +82,63 @@ mod tests {
             .map(ToString::to_string)
             .collect(),
             init: PathBuf::from("/nix/store/xxx-nixos-system-xxx/init"),
-            initrd: PathBuf::from("/nix/store/xxx-initrd-linux/initrd"),
+            initrd: Some(PathBuf::from("/nix/store/xxx-initrd-linux/initrd")),
             initrd_secrets: Some(PathBuf::from(
                 "/nix/store/xxx-append-secrets/bin/append-initrd-secrets",
             )),
+            specialisation: HashMap::new(),
+            toplevel: SystemConfigurationRoot(PathBuf::from("/nix/store/xxx-nixos-system-xxx")),
+        };
+
+        assert_eq!(from_json, expected);
+    }
+
+    #[test]
+    fn valid_v1_json_without_initrd() {
+        let json = r#"{
+    "v1": {
+        "system": "x86_64-linux",
+        "init": "/nix/store/xxx-nixos-system-xxx/init",
+        "kernel": "/nix/store/xxx-linux/bzImage",
+        "kernelParams": [
+            "amd_iommu=on",
+            "amd_iommu=pt",
+            "iommu=pt",
+            "kvm.ignore_msrs=1",
+            "kvm.report_ignored_msrs=0",
+            "udev.log_priority=3",
+            "systemd.unified_cgroup_hierarchy=1",
+            "loglevel=4"
+        ],
+        "label": "NixOS 21.11.20210810.dirty (Linux 5.15.30)",
+        "toplevel": "/nix/store/xxx-nixos-system-xxx",
+        "specialisation": {}
+    }
+}"#;
+
+        let from_json: Generation = serde_json::from_str(&json).unwrap();
+        let Generation::V1(from_json) = from_json;
+
+        let expected = crate::v1::GenerationV1 {
+            system: String::from("x86_64-linux"),
+            label: String::from("NixOS 21.11.20210810.dirty (Linux 5.15.30)"),
+            kernel: PathBuf::from("/nix/store/xxx-linux/bzImage"),
+            kernel_params: vec![
+                "amd_iommu=on",
+                "amd_iommu=pt",
+                "iommu=pt",
+                "kvm.ignore_msrs=1",
+                "kvm.report_ignored_msrs=0",
+                "udev.log_priority=3",
+                "systemd.unified_cgroup_hierarchy=1",
+                "loglevel=4",
+            ]
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
+            init: PathBuf::from("/nix/store/xxx-nixos-system-xxx/init"),
+            initrd: None,
+            initrd_secrets: None,
             specialisation: HashMap::new(),
             toplevel: SystemConfigurationRoot(PathBuf::from("/nix/store/xxx-nixos-system-xxx")),
         };

--- a/bootspec/src/v1.rs
+++ b/bootspec/src/v1.rs
@@ -33,7 +33,7 @@ pub struct GenerationV1 {
     /// Path to the init script
     pub init: PathBuf,
     /// Path to initrd -- $toplevel/initrd
-    pub initrd: PathBuf,
+    pub initrd: Option<PathBuf>,
     /// Path to "append-initrd-secrets" script -- $toplevel/append-initrd-secrets
     pub initrd_secrets: Option<PathBuf>,
     /// Mapping of specialisation names to their boot.json
@@ -105,8 +105,15 @@ impl GenerationV1 {
 
         let init = generation.join("init");
 
-        let initrd = fs::canonicalize(generation.join("initrd"))
-            .map_err(|e| format!("Failed to canonicalize the initrd:\n{}", e))?;
+        let initrd_path = generation.join("initrd");
+        let initrd = if initrd_path.exists() {
+            Some(
+                fs::canonicalize(initrd_path)
+                    .map_err(|e| format!("Failed to canonicalize the initrd:\n{}", e))?,
+            )
+        } else {
+            None
+        };
 
         let initrd_secrets = if generation.join("append-initrd-secrets").exists() {
             Some(generation.join("append-initrd-secrets"))
@@ -239,7 +246,7 @@ mod tests {
                 kernel: generation.join("kernel-modules/bzImage"),
                 kernel_params,
                 init: generation.join("init"),
-                initrd: generation.join("initrd"),
+                initrd: Some(generation.join("initrd")),
                 initrd_secrets: Some(generation.join("append-initrd-secrets")),
                 specialisation: HashMap::new(),
                 toplevel: SystemConfigurationRoot(generation),
@@ -309,7 +316,7 @@ mod tests {
                 kernel: generation.join("kernel-modules/bzImage"),
                 kernel_params,
                 init: generation.join("init"),
-                initrd: generation.join("initrd"),
+                initrd: Some(generation.join("initrd")),
                 initrd_secrets: Some(generation.join("append-initrd-secrets")),
                 specialisation: HashMap::new(),
                 toplevel: SystemConfigurationRoot(generation),

--- a/bootspec/src/v1.rs
+++ b/bootspec/src/v1.rs
@@ -16,8 +16,6 @@ pub const JSON_FILENAME: &str = "boot.v1.json";
 #[serde(rename_all = "camelCase")]
 /// V1 of the bootspec schema.
 ///
-/// It has a `schemaVersion` field that will always be 1.
-///
 /// ## Warnings
 ///
 /// Do not attempt to deserialize this struct from a bootspec document, as it does not enforce

--- a/synthesize/integration-test-cases/expected-synthesis/15.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/15.09-plain.json
@@ -9,6 +9,7 @@
     "initrd": "/nix/store/gqdm8dk6my53kvn23r81win9vadjqv80-initrd/initrd",
     "initrdSecrets": null,
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/fl1c8cclzzri16zimdfz8wp31w5yc7dp-nixos-15.09pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/16.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/16.03-plain.json
@@ -9,6 +9,7 @@
     "initrd": "/nix/store/q1hg158mvnc9bscc22cv45ys484c4g9x-initrd/initrd",
     "initrdSecrets": null,
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/k0lfhjxd5znyrqkgrdi3hh7wxr885fcj-nixos-system-nixos-16.03pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/16.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/16.09-plain.json
@@ -9,6 +9,7 @@
     "initrd": "/nix/store/rv6i771w5z01z1xvylxhymp5pw44wc6j-initrd/initrd",
     "initrdSecrets": null,
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/jfwlp9s434kijn4i53fr5pvrryzspwc4-nixos-system-nixos-16.09pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/17.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/17.03-plain.json
@@ -9,6 +9,7 @@
     "initrd": "/nix/store/spbi6va9dmd41rg15nd9wxjj94097q49-initrd/initrd",
     "initrdSecrets": null,
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/51yf3by1xpzawi30a1rny34gm1047vg8-nixos-system-nixos-17.03pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/17.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/17.09-plain.json
@@ -9,6 +9,7 @@
     "initrd": "/nix/store/nnyp0dqb62dicr9wyw2ykcrc0vk7f5mf-initrd/initrd",
     "initrdSecrets": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git/append-initrd-secrets",
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/bxahnn6p04ydz5a02002pjcmgqfmq509-nixos-system-nixos-17.09pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/18.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/18.03-plain.json
@@ -9,6 +9,7 @@
     "initrd": "/nix/store/gnjk07h7ynhp3f8x145dv224j0wf0s1h-initrd/initrd",
     "initrdSecrets": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git/append-initrd-secrets",
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/jr5bql6xdfhhv4bmibiz3b74pjp8sdca-nixos-system-nixos-18.03pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/18.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/18.09-plain.json
@@ -9,6 +9,7 @@
     "initrd": "/nix/store/2ib32agl00qy7sf7ka5sdbrl6kg4b9gi-initrd/initrd",
     "initrdSecrets": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git/append-initrd-secrets",
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/b96sr7vmv90wxfjfk2d7icxh7d77a1na-nixos-system-nixos-18.09pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/19.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/19.03-plain.json
@@ -9,6 +9,7 @@
     "initrd": "/nix/store/fv9ag95k2ww4w87grwj6hg0b25is5giy-initrd/initrd",
     "initrdSecrets": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git/append-initrd-secrets",
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/wp2gq8zzcixy2d1dvswhbhdl532jxhsf-nixos-system-nixos-19.03pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/19.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/19.09-plain.json
@@ -10,6 +10,7 @@
     "initrd": "/nix/store/d6xpsfsby2y1d2hvfhdgss45swrazipf-initrd-linux-4.19.78/initrd",
     "initrdSecrets": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git/append-initrd-secrets",
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/wqr3p7hd4x59g14zx7qkz8sqvgl9ngvl-nixos-system-nixos-19.09pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/20.03-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/20.03-plain.json
@@ -10,6 +10,7 @@
     "initrd": "/nix/store/1j7s94v0axvgwcv4s0ka56xmgvffdlc0-initrd-linux-5.4.33/initrd",
     "initrdSecrets": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git/append-initrd-secrets",
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/l651p9fhdwkn7p49vawif8a2b4v1nsfl-nixos-system-nixos-20.03pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/20.09-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/20.09-plain.json
@@ -10,6 +10,7 @@
     "initrd": "/nix/store/r7ifs7qvxb5fdz7hhjh5m8a65k34ik25-initrd-linux-5.4.72/initrd",
     "initrdSecrets": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git/append-initrd-secrets",
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/6621qzx8dlvwgpjjs1sarw9lxv4x38ps-nixos-system-nixos-20.09pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/21.05-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/21.05-plain.json
@@ -10,6 +10,7 @@
     "initrd": "/nix/store/5ci6pag0hclx1642nm5rs6zjl60drns4-initrd-linux-5.10.37/initrd",
     "initrdSecrets": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git/append-initrd-secrets",
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/sz7d2wmq5jx4rrdmx2ksb9wmc5raqvwn-nixos-system-nixos-21.05pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/21.11-plain.json
+++ b/synthesize/integration-test-cases/expected-synthesis/21.11-plain.json
@@ -10,6 +10,7 @@
     "initrd": "/nix/store/69bhfdfv77y0vclnlxqrd8pxjzbkz47w-initrd-linux-5.10.81/initrd",
     "initrdSecrets": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
     "specialisation": {},
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/7xvzw9yxw91vklhyzf0isg9256xh1l5l-nixos-system-nixos-21.11pre-git"
   }
 }

--- a/synthesize/integration-test-cases/expected-synthesis/21.11-specialisations.json
+++ b/synthesize/integration-test-cases/expected-synthesis/21.11-specialisations.json
@@ -21,9 +21,11 @@
         "initrd": "/nix/store/69bhfdfv77y0vclnlxqrd8pxjzbkz47w-initrd-linux-5.10.81/initrd",
         "initrdSecrets": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git/append-initrd-secrets",
         "specialisation": {},
+        "system": "x86_64-linux",
         "toplevel": "/nix/store/3w5kr91xq46638fd310q2sa9mjm6r6hn-nixos-system-nixos-21.11pre-git"
       }
     },
+    "system": "x86_64-linux",
     "toplevel": "/nix/store/kgkjwhscv52r2y1ha1y19lb9h4j3lfrc-nixos-system-nixos-21.11pre-git"
   }
 }


### PR DESCRIPTION
##### Description

This renders initrd optional and introduces a system field.
Also, cleanup mention of `schemaVersion` field.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Built with `cargo build`
- [x] Formatted with `cargo fmt`
- [x] Linted with `cargo clippy`
- [x] Ran tests with `cargo test`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
