### PR TITLE
bootspec: fix JSON_FILENAME constant

### DIFF
--- a/bootspec/src/lib.rs
+++ b/bootspec/src/lib.rs
@@ -17,10 +17,11 @@ pub struct SpecialisationName(pub String);
 /// A wrapper type describing the root directory of a NixOS system configuration.
 pub struct SystemConfigurationRoot(pub PathBuf);
 
-// !!! IMPORTANT: KEEP `BootJson`, `SCHEMA_VERSION`, and `JSON_FILENAME` IN SYNC !!!
+/// The bootspec schema filename.
+pub const JSON_FILENAME: &str = "boot.json";
+
+// !!! IMPORTANT: KEEP `BootJson` and `SCHEMA_VERSION` IN SYNC !!!
 /// The current bootspec schema.
 pub type BootJson = v1::GenerationV1;
 /// The current bootspec schema version.
 pub const SCHEMA_VERSION: u64 = v1::SCHEMA_VERSION;
-/// The current bootspec schema filename.
-pub const JSON_FILENAME: &str = v1::JSON_FILENAME;

--- a/bootspec/src/v1.rs
+++ b/bootspec/src/v1.rs
@@ -9,9 +9,6 @@ use crate::{Result, SpecialisationName, SystemConfigurationRoot};
 /// The V1 bootspec schema version.
 pub const SCHEMA_VERSION: u64 = 1;
 
-/// The V1 bootspec schema filename.
-pub const JSON_FILENAME: &str = "boot.v1.json";
-
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 /// V1 of the bootspec schema.
@@ -138,7 +135,8 @@ mod tests {
     use std::path::PathBuf;
     use std::{collections::HashMap, fs};
 
-    use super::{GenerationV1, SystemConfigurationRoot, JSON_FILENAME};
+    use super::{GenerationV1, SystemConfigurationRoot};
+    use crate::JSON_FILENAME;
     use tempfile::TempDir;
 
     fn create_generation_files_and_dirs(


### PR DESCRIPTION
The RFC moved away from versioned filenames a while ago.

##### Description

Fixes https://github.com/DeterminateSystems/bootspec/issues/70.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Built with `cargo build`
- [x] Formatted with `cargo fmt`
- [x] Linted with `cargo clippy`
- [x] Ran tests with `cargo test`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
