### PR TITLE
bootspec(generation): offer TryInto conversion from Generation to any…

### DIFF
--- a/bootspec/src/generation.rs
+++ b/bootspec/src/generation.rs
@@ -33,6 +33,17 @@ impl Generation {
     }
 }
 
+impl TryInto<v1::GenerationV1> for Generation {
+    type Error = String;
+
+    fn try_into(self) -> Result<v1::GenerationV1, Self::Error> {
+        match self {
+            Self::V1(gen) => Ok(gen),
+            _ => return Err(format!("Invalid schema version, expected version 1, got: {}", self.version()).to_string())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;


### PR DESCRIPTION
##### Description

… schema version

Enables replacing:

```
        // TODO: replace me when https://github.com/DeterminateSystems/bootspec/pull/109 lands.
        let bootspec: BootSpec = match boot_json.generation {
            BootspecGeneration::V1(bootspec) => bootspec,
            _ => return Err(anyhow!("Unsupported bootspec schema"))
        };
```

by

```
        let bootspec: BootSpec = boot_json.generation.try_into().map_err(|err| ...);
```


##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [ ] Built with `cargo build`
- [ ] Formatted with `cargo fmt`
- [ ] Linted with `cargo clippy`
- [ ] Ran tests with `cargo test`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
