### PR TITLE
bootspec: relax the extensions type

### DIFF
--- a/bootspec/src/generation.rs
+++ b/bootspec/src/generation.rs
@@ -195,10 +195,7 @@ mod tests {
         };
         let expected = BootJson {
             generation: Generation::V1(generation),
-            extensions: HashMap::from([(
-                "org.test".into(),
-                HashMap::from([("key".into(), serde_json::to_value("hello").unwrap())]),
-            )]),
+            extensions: HashMap::from([("org.test".into(), serde_json::json!({ "key": "hello" }))]),
         };
 
         let from_extension: TestExtension = Deserialize::deserialize(
@@ -307,7 +304,9 @@ mod tests {
     "org.test": null
 }"#;
         let json_err = serde_json::from_str::<BootJson>(&json).unwrap_err();
-        assert!(json_err.to_string().contains("expected a map"));
+        assert!(json_err
+            .to_string()
+            .contains("org.test was null, but null extensions are not allowed"));
     }
 
     #[test]

--- a/bootspec/src/generation.rs
+++ b/bootspec/src/generation.rs
@@ -301,6 +301,7 @@ mod tests {
         "toplevel": "/nix/store/xxx-nixos-system-xxx"
     },
     "org.nixos.specialisation.v1": {},
+    "org.test2": { "hi": null },
     "org.test": null
 }"#;
         let json_err = serde_json::from_str::<BootJson>(&json).unwrap_err();

--- a/bootspec/src/lib.rs
+++ b/bootspec/src/lib.rs
@@ -31,10 +31,8 @@ pub struct SystemConfigurationRoot(pub PathBuf);
 
 /// The bootspec schema filename.
 pub const JSON_FILENAME: &str = "boot.json";
-/// The type for a generic extensions.
-pub type Extension = HashMap<String, serde_json::Value>;
 /// The type for a collection of generic extensions.
-pub type Extensions = HashMap<String, Extension>;
+pub type Extensions = HashMap<String, serde_json::Value>;
 
 // !!! IMPORTANT: KEEP `BootSpec`, `Specialisations`, and `SCHEMA_VERSION` IN SYNC !!!
 /// The current bootspec generation type.


### PR DESCRIPTION
Prior to this change, extensions would need to round-trip through serde_json in order to be able to become a given extension type:

    let extension: HashMap<String, serde_json::Value> = bootspec.extensions.get("org.test").unwrap();
    let extension: OrgTestExtension = serde_json::from_value(serde_json::to_value(extension).unwrap()).unwrap();

Now, however, you can directly deserialize the extension into a type:

    let extension: serde_json::Value = bootspec.extensions.get("org.test").unwrap();
    let extension: OrgTestExtension = serde_json::from_value(extension).unwrap();

##### Description

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [ ] Built with `cargo build`
- [ ] Formatted with `cargo fmt`
- [ ] Linted with `cargo clippy`
- [ ] Ran tests with `cargo test`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)