### PR TITLE
feat: read the full specialisation schema from bootspec

### DIFF
--- a/bootspec/rfc0125_spec.json
+++ b/bootspec/rfc0125_spec.json
@@ -20,6 +20,9 @@
   },
   "org.nixos.specialisation.v1": {
     "<name>": {
+      "org.nix-community.test": {
+        "foo": "bar"
+      },
       "org.nixos.bootspec.v1": {
         "system": "x86_64-linux",
         "init": "/nix/store/xxx-nixos-system-xxx/init",

--- a/bootspec/src/generation.rs
+++ b/bootspec/src/generation.rs
@@ -88,6 +88,22 @@ mod tests {
             .map(ToOwned::to_owned)
             .collect::<Vec<_>>();
         assert!(keys.contains(&SpecialisationName(String::from("<name>"))));
+
+        assert_eq!(
+            from_json
+                .specialisations
+                .get(&SpecialisationName("<name>".into()))
+                .unwrap()
+                .extensions
+                .get("org.nix-community.test")
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get("foo")
+                .unwrap()
+                .as_str(),
+            Some("bar")
+        )
     }
 
     #[test]

--- a/bootspec/src/lib.rs
+++ b/bootspec/src/lib.rs
@@ -34,11 +34,13 @@ pub const JSON_FILENAME: &str = "boot.json";
 /// The type for a collection of generic extensions.
 pub type Extensions = HashMap<String, serde_json::Value>;
 
-// !!! IMPORTANT: KEEP `BootSpec`, `Specialisations`, and `SCHEMA_VERSION` IN SYNC !!!
+// !!! IMPORTANT: KEEP `BootSpec`, `Specialisations`, `Specialisation`, and `SCHEMA_VERSION` IN SYNC !!!
 /// The current bootspec generation type.
 pub type BootSpec = v1::GenerationV1;
 /// The current specialisations type.
 pub type Specialisations = v1::SpecialisationsV1;
+/// The current specialisations type.
+pub type Specialisation = v1::SpecialisationV1;
 /// The current bootspec schema version.
 pub const SCHEMA_VERSION: u64 = v1::SCHEMA_VERSION;
 

--- a/bootspec/src/v1.rs
+++ b/bootspec/src/v1.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{BootspecError, SynthesizeError};
-use crate::{Result, SpecialisationName, SystemConfigurationRoot};
+use crate::{BootJson, Result, SpecialisationName, SystemConfigurationRoot};
 
 /// The V1 bootspec schema version.
 pub const SCHEMA_VERSION: u64 = 1;
@@ -48,7 +48,7 @@ impl GenerationV1 {
 
                 specialisations.insert(
                     SpecialisationName(name.to_string()),
-                    Self::synthesize(&toplevel)?,
+                    BootJson::synthesize_version(&toplevel, SCHEMA_VERSION)?,
                 );
             }
         }
@@ -63,7 +63,7 @@ impl GenerationV1 {
 /// A mapping of V1 bootspec specialisations.
 ///
 /// This structure represents the contents of the `org.nixos.specialisations.v1` key.
-pub type SpecialisationsV1 = HashMap<SpecialisationName, GenerationV1>;
+pub type SpecialisationsV1 = HashMap<SpecialisationName, BootJson>;
 
 /// A V1 bootspec toplevel.
 ///

--- a/bootspec/src/v1.rs
+++ b/bootspec/src/v1.rs
@@ -5,8 +5,9 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::deser;
 use crate::error::{BootspecError, SynthesizeError};
-use crate::{BootJson, Result, SpecialisationName, SystemConfigurationRoot};
+use crate::{Extensions, Result, SpecialisationName, SystemConfigurationRoot};
 
 /// The V1 bootspec schema version.
 pub const SCHEMA_VERSION: u64 = 1;
@@ -48,7 +49,7 @@ impl GenerationV1 {
 
                 specialisations.insert(
                     SpecialisationName(name.to_string()),
-                    BootJson::synthesize_version(&toplevel, SCHEMA_VERSION)?,
+                    SpecialisationV1::synthesize(&toplevel)?,
                 );
             }
         }
@@ -62,8 +63,37 @@ impl GenerationV1 {
 
 /// A mapping of V1 bootspec specialisations.
 ///
-/// This structure represents the contents of the `org.nixos.specialisations.v1` key.
-pub type SpecialisationsV1 = HashMap<SpecialisationName, BootJson>;
+/// This structure represents the contents of the `org.nixos.specialisation.v1` key.
+pub type SpecialisationsV1 = HashMap<SpecialisationName, SpecialisationV1>;
+
+/// A V1 bootspec specialisation.
+///
+/// This structure represents a single specialisation contained in the `org.nixos.specialisation.v1` key.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpecialisationV1 {
+    #[serde(flatten)]
+    pub generation: GenerationV1,
+    #[serde(
+        default = "HashMap::new",
+        skip_serializing_if = "HashMap::is_empty",
+        deserialize_with = "deser::skip_generation_fields",
+        flatten
+    )]
+    pub extensions: Extensions,
+}
+
+impl SpecialisationV1 {
+    /// Synthesize a [`SpecialisationV1`] struct from the path to a NixOS generation.
+    ///
+    /// This is useful when used on generations that do not have a bootspec attached to it.
+    pub fn synthesize(generation_path: &Path) -> Result<Self> {
+        let generation = GenerationV1::synthesize(generation_path)?;
+        Ok(Self {
+            generation,
+            extensions: HashMap::new(),
+        })
+    }
+}
 
 /// A V1 bootspec toplevel.
 ///


### PR DESCRIPTION
##### Description

This fixes https://github.com/DeterminateSystems/bootspec/issues/147 by changing the type of specialisations from `Generation` to `BootJson`.
This means that we capture the full recursive JSON schema for specialisations, including extensions, while the previous type threw this information away.

This allows for instance to set specific sort keys for specialisations.
Such sort keys are allowed by the bootspec specification, but are currently not retained when parsing a bootspec document.

This changes the public type of the specialisations field, so it should be considered a breaking change.
<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Built with `cargo build`
- [x] Formatted with `cargo fmt`
- [x] Linted with `cargo clippy`
- [x] Ran tests with `cargo test`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support for nested extension metadata within specialisations; custom extension fields are preserved and accessible.

- Refactor
  - Internal representation of specialisations updated to improve compatibility and future extensibility; no action needed for typical configs.

- Tests
  - Added coverage verifying parsing of nested extension objects and string fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->