### PR TITLE
 bootspec: bump to v2.0.0 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bootspec"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/bootspec/Cargo.toml
+++ b/bootspec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bootspec"
-version = "1.1.0"
+version = "2.0.0"
 edition = "2021"
 description = "An implementation of NixOS RFC 125's bootspec datatype"
 license = "MIT"

--- a/bootspec/README.md
+++ b/bootspec/README.md
@@ -5,3 +5,7 @@ This crate provides various structures and constants useful for interacting with
 See: https://github.com/NixOS/rfcs/pull/125.
 
 The `BootJson` struct implements the `serde::Deserialize` and `serde::Serialize` traits, making it easy to work with existing bootspec documents as well as creating new ones.
+
+## Versioning
+
+* `bootspec` crate versions `1.x` and `2.x` are compatible with [bootspec V1](https://github.com/NixOS/rfcs/pull/125).


### PR DESCRIPTION
https://github.com/DeterminateSystems/bootspec/pull/207 changed the public API in a backwards-incompatible way, we need to release the next version as 2.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a Versioning section clarifying compatibility between bootspec crate 1.x/2.x and bootspec V1, providing clearer guidance for upgrades and integrations. Existing projects remain compatible; examples and usage are unaffected.

- Chores
  - Increased the package version to 2.0.0 to align with the documented compatibility policy; metadata update only.

- Note
  - No functional changes to features, APIs, or behavior in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->