### PR TITLE
Re-work flake outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,44 +8,44 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-    - uses: DeterminateSystems/determinate-nix-action@main
-    - uses: DeterminateSystems/flakehub-cache-action@main
-    - name: Check rustfmt
-      run: nix develop --command cargo fmt -- --check
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/determinate-nix-action@main
+      - uses: DeterminateSystems/flakehub-cache-action@main
+      - name: Check rustfmt
+        run: nix develop --command cargo fmt -- --check
 
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-    - uses: DeterminateSystems/determinate-nix-action@main
-    - uses: DeterminateSystems/flakehub-cache-action@main
-    - name: Build
-      run: nix build -L
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/determinate-nix-action@main
+      - uses: DeterminateSystems/flakehub-cache-action@main
+      - name: Build
+        run: nix build -L
 
   NixFlakeCheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-    - uses: DeterminateSystems/flake-checker-action@main
-      with:
-        fail-mode: false
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/flake-checker-action@main
+        with:
+          fail-mode: false
 
   NixFormatting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-    - uses: DeterminateSystems/determinate-nix-action@main
-    - uses: DeterminateSystems/flakehub-cache-action@main
-    - name: Check nixpkgs-fmt formatting
-      run: nix develop --command sh -c "git ls-files '*.nix' | xargs nixpkgs-fmt --check"
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: DeterminateSystems/determinate-nix-action@main
+      - uses: DeterminateSystems/flakehub-cache-action@main
+      - name: Check Nix formatting
+        run: nix develop --command sh -c "git ls-files '*.nix' | xargs nixfmt check"
 
   EditorConfig:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: greut/eclint-action@v0
@@ -53,23 +53,23 @@ jobs:
   ValidateJsonSchema:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-    - uses: DeterminateSystems/determinate-nix-action@main
-    - uses: DeterminateSystems/flakehub-cache-action@main
-    - name: Validate JSON Schema
-      run: nix develop --command jv ./schema.json
-    - name: Validate JSON Schema against example
-      run: nix develop --command jv ./schema.json ./bootspec/rfc0125_spec.json
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: DeterminateSystems/determinate-nix-action@main
+      - uses: DeterminateSystems/flakehub-cache-action@main
+      - name: Validate JSON Schema
+        run: nix develop --command jv ./schema.json
+      - name: Validate JSON Schema against example
+        run: nix develop --command jv ./schema.json ./bootspec/rfc0125_spec.json
 
   SynthesizeIntegration:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-    - uses: DeterminateSystems/determinate-nix-action@main
-    - uses: DeterminateSystems/flakehub-cache-action@main
-    - name: Verify synthesize integration test still passes
-      run: nix develop -c ./synthesize/integration-test-cases/verify.sh
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: DeterminateSystems/determinate-nix-action@main
+      - uses: DeterminateSystems/flakehub-cache-action@main
+      - name: Verify synthesize integration test still passes
+        run: nix develop -c ./synthesize/integration-test-cases/verify.sh

--- a/.github/workflows/json-schema.yaml
+++ b/.github/workflows/json-schema.yaml
@@ -15,22 +15,22 @@ jobs:
       pages: write
       id-token: write
     steps:
-    - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-    - uses: DeterminateSystems/determinate-nix-action@main
-    - uses: DeterminateSystems/flakehub-cache-action@main
-    - name: Set up GitHub Pages
-      uses: actions/configure-pages@v5
-    - name: Generate JSON Schema docs
-      id: generate
-      run: |
-        mkdir -p dist
-        nix develop --command generate-schema-doc --config expand_buttons=true schema.json dist/index.html
-    - name: Upload docs
-      uses: actions/upload-pages-artifact@v4
-      with:
-        path: ./dist
-    - name: Publish docs to GitHub Pages
-      id: publish
-      uses: actions/deploy-pages@v4
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: DeterminateSystems/determinate-nix-action@main
+      - uses: DeterminateSystems/flakehub-cache-action@main
+      - name: Set up GitHub Pages
+        uses: actions/configure-pages@v5
+      - name: Generate JSON Schema docs
+        id: generate
+        run: |
+          mkdir -p dist
+          nix develop --command generate-schema-doc --config expand_buttons=true schema.json dist/index.html
+      - name: Upload docs
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./dist
+      - name: Publish docs to GitHub Pages
+        id: publish
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -3,13 +3,13 @@ name: update-flake-lock
 on:
   workflow_dispatch: # enable manual triggering
   schedule:
-    - cron: '0 0 * * 0' # every Sunday at midnight
+    - cron: "0 0 * * 0" # every Sunday at midnight
 
 jobs:
   lockfile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
       - uses: DeterminateSystems/update-flake-lock@main

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,14 +2,14 @@ name: update-flake-lock
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: "0 0 * * 0"
 
 jobs:
   lockfile:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Check flake
         uses: DeterminateSystems/flake-checker-action@main
         with:

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,4 @@
-(import
-  (fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
-    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
-  })
-  { src = ./.; }).defaultNix
+(import (fetchTarball {
+  url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+  sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
+}) { src = ./.; }).defaultNix

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,12 @@
-(import (fetchTarball {
-  url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
-  sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
-}) { src = ./.; }).defaultNix
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/NixOS/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -16,12 +16,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773389992,
-        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
-        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
-        "revCount": 962836,
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "revCount": 1004030,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.962836%2Brev-c06b4ae3d6599a672a6210b7021d699c351eebda/019cec4e-dd38-75a8-9d2d-0d91492115c9/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1004030%2Brev-64c08a7ca051951c8eae34e3e3cb1e202fe36786/019e5fd8-b716-7e01-9710-e44ec43dc50b/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,36 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "flake-compat": {
       "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
-        "type": "github"
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773389992,
+        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
+        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
+        "revCount": 962836,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.962836%2Brev-c06b4ae3d6599a672a6210b7021d699c351eebda/019cec4e-dd38-75a8-9d2d-0d91492115c9/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1"
       }
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,23 +3,35 @@
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
-  outputs = inputs:
+  outputs =
+    { self, ... }@inputs:
     let
-      nameValuePair = name: value: { inherit name value; };
-      genAttrs = names: f: builtins.listToAttrs (map (n: nameValuePair n (f n)) names);
-      allSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      inherit (inputs.nixpkgs) lib;
 
-      forAllSystems = f: genAttrs allSystems (system: f {
-        inherit system;
-        pkgs = import inputs.nixpkgs { inherit system; };
-      });
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forEachSupportedSystem =
+        f:
+        lib.genAttrs supportedSystems (
+          system:
+          f {
+            inherit system;
+            pkgs = import inputs.nixpkgs { inherit system; };
+          }
+        );
     in
     {
-      devShell = forAllSystems ({ system, pkgs, ... }:
+      devShell = forEachSupportedSystem (
+        { system, pkgs }:
         pkgs.mkShell {
           name = "bootspec";
 
-          buildInputs = with pkgs; [
+          packages = with pkgs; [
             cargo
             rustc
             clippy
@@ -29,21 +41,22 @@
             jsonschema # provides the jv tool
             json-schema-for-humans # provides the generate-schema-doc tool
           ];
-        });
+        }
+      );
 
-      packages = forAllSystems
-        ({ system, pkgs, ... }:
-          {
-            package = pkgs.rustPlatform.buildRustPackage rec {
-              pname = "bootspec";
-              version = "unreleased";
+      packages = forEachSupportedSystem (
+        { system, pkgs }:
+        {
+          default = self.packages.${system}.bootspec;
+          bootspec = pkgs.rustPlatform.buildRustPackage rec {
+            pname = "bootspec";
+            version = "unreleased";
 
-              src = inputs.self;
+            src = inputs.self;
 
-              cargoLock.lockFile = ./Cargo.lock;
-            };
-          });
-
-      defaultPackage = forAllSystems ({ system, ... }: inputs.self.packages.${system}.package);
+            cargoLock.lockFile = ./Cargo.lock;
+          };
+        }
+      );
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,10 @@
 {
-  description = "bootloader-experimentation";
+  description = "Bootspec: an implementation of RFC-0125's data type and synthesis tooling";
 
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs = {
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
+    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1";
+  };
 
   outputs =
     { self, ... }@inputs:
@@ -11,7 +14,6 @@
       supportedSystems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
 
@@ -26,33 +28,35 @@
         );
     in
     {
-      devShell = forEachSupportedSystem (
-        { system, pkgs }:
-        pkgs.mkShell {
-          name = "bootspec";
+      devShells = forEachSupportedSystem (
+        { pkgs, system }:
+        {
+          default = pkgs.mkShell {
+            name = "bootspec";
 
-          packages = with pkgs; [
-            cargo
-            rustc
-            clippy
-            codespell
-            nixpkgs-fmt
-            rustfmt
-            jsonschema # provides the jv tool
-            json-schema-for-humans # provides the generate-schema-doc tool
-          ];
+            packages = with pkgs; [
+              cargo
+              rustc
+              clippy
+              codespell
+              nixpkgs-fmt
+              rustfmt
+              jsonschema # provides the jv tool
+              json-schema-for-humans # provides the generate-schema-doc tool
+            ];
+          };
         }
       );
 
       packages = forEachSupportedSystem (
-        { system, pkgs }:
+        { pkgs, system }:
         {
           default = self.packages.${system}.bootspec;
-          bootspec = pkgs.rustPlatform.buildRustPackage rec {
+          bootspec = pkgs.rustPlatform.buildRustPackage {
             pname = "bootspec";
             version = "unreleased";
 
-            src = inputs.self;
+            src = self;
 
             cargoLock.lockFile = ./Cargo.lock;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -39,10 +39,10 @@
               rustc
               clippy
               codespell
-              nixpkgs-fmt
               rustfmt
               jsonschema # provides the jv tool
               json-schema-for-humans # provides the generate-schema-doc tool
+              self.formatter.${system}
             ];
           };
         }
@@ -62,5 +62,7 @@
           };
         }
       );
+
+      formatter = forEachSupportedSystem ({ pkgs, ... }: pkgs.nixfmt);
     };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,4 @@
-(import
-  (fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
-    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
-  })
-  { src = ./.; }).shellNix
+(import (fetchTarball {
+  url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+  sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
+}) { src = ./.; }).shellNix

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,12 @@
-(import (fetchTarball {
-  url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
-  sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
-}) { src = ./.; }).shellNix
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/NixOS/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).shellNix

--- a/synthesize/integration-test-cases/21.11-specialisations.nix
+++ b/synthesize/integration-test-cases/21.11-specialisations.nix
@@ -8,11 +8,14 @@ in
   configuration = {
     imports = [
       "${src}/nixos/modules/virtualisation/qemu-vm.nix"
-      ({ pkgs, ... }: {
-        specialisation.example.configuration = {
-          environment.systemPackages = [ pkgs.hello ];
-        };
-      })
+      (
+        { pkgs, ... }:
+        {
+          specialisation.example.configuration = {
+            environment.systemPackages = [ pkgs.hello ];
+          };
+        }
+      )
     ];
   };
 }).config.system.build.toplevel


### PR DESCRIPTION
I noticed that this was still using `defaultPackage` so I fixed that and did some other sprucing-up-type things, like reformatting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized flake/layout to produce per-system dev shells and packages for clearer system-specific builds.

* **Chores**
  * Switched CI workflow checkout action to a newer version and adjusted related workflow step structure.
  * Made lockfile-driven sourcing more dynamic to follow the project's lock information.

* **Style**
  * Reformatted several configuration imports and wrapped expressions for consistent readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->